### PR TITLE
add dummy serializeable interfaces

### DIFF
--- a/src/oisst/Increment/Increment.h
+++ b/src/oisst/Increment/Increment.h
@@ -14,13 +14,15 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <vector>
 
 #include <boost/shared_ptr.hpp>
 
+#include "oops/base/GeneralizedDepartures.h"
 #include "oops/base/Variables.h"
 #include "oops/util/DateTime.h"
 #include "oops/util/Printable.h"
-#include "oops/base/GeneralizedDepartures.h"
+#include "oops/util/Serializable.h"
 
 // forward declarations
 namespace oops {
@@ -42,6 +44,7 @@ namespace oisst {
   // Increment class
   class Increment : public oops::GeneralizedDepartures,
                     public util::Printable,
+                    public util::Serializable,
                     private util::ObjectCounter<Increment> {
    public:
     static const std::string classname() {return "oisst::Increment";}
@@ -54,7 +57,7 @@ namespace oisst {
     Increment(const Increment &);
     ~Increment();
 
-        // Math operators
+    // Math operators
     Increment & operator =(const Increment &);
     Increment & operator-=(const Increment &);
     Increment & operator+=(const Increment &);
@@ -84,8 +87,13 @@ namespace oisst {
     void read(const eckit::Configuration &);
     void write(const eckit::Configuration &) const;
 
+    // Serialize and deserialize (not needed by our project)
+    size_t serialSize() const override { return 0; }
+    void serialize(std::vector<double> &) const override {}
+    void deserialize(const std::vector<double> &, size_t &) override {}
+
    private:
-    void print(std::ostream &) const;
+    void print(std::ostream &) const override;
 
     boost::shared_ptr<const Geometry> geom_;
     util::DateTime time_;

--- a/src/oisst/ModelAux/ModelAuxIncrement.h
+++ b/src/oisst/ModelAux/ModelAuxIncrement.h
@@ -10,9 +10,11 @@
 
 #include <ostream>
 #include <string>
+#include <vector>
 
 #include "oops/util/ObjectCounter.h"
 #include "oops/util/Printable.h"
+#include "oops/util/Serializable.h"
 
 // forward declarations
 namespace eckit {
@@ -29,6 +31,7 @@ namespace oisst {
 
   // ModelAuxControl class
   class ModelAuxIncrement : public util::Printable,
+                            public util::Serializable,
                             private util::ObjectCounter<ModelAuxIncrement> {
    public:
     static const std::string classname() {return "oisst::ModelAuxIncrement";}
@@ -49,8 +52,13 @@ namespace oisst {
     double norm() const;
     void zero();
 
+    // serialize and deserialize
+    size_t serialSize() const override {return 0;}
+    void serialize(std::vector<double> &) const override {}
+    void deserialize(const std::vector<double> &, size_t &) override {}
+
    private:
-    void print(std::ostream &) const;
+    void print(std::ostream &) const override;
   };
 }  // namespace oisst
 #endif  // OISST_MODELAUX_MODELAUXINCREMENT_H_


### PR DESCRIPTION
Adds dummy serializable interfaces to `Increment` and `ModelAuxIncrement`. 
These are required by a recent change to oops, but since they are needed primarily for ensemble applications we don't actually needed them and so we can get away with just having these dummy implementations.
- closes #4