### PR TITLE
add serializable interfaces to State

### DIFF
--- a/src/oisst/State/State.h
+++ b/src/oisst/State/State.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <vector>
 
 #include <boost/shared_ptr.hpp>
 
@@ -40,6 +41,7 @@ namespace oisst {
 
   // State class
   class State : public util::Printable,
+                public util::Serializable,
                 private util::ObjectCounter<State> {
    public:
     static const std::string classname() {return "oisst::State";}
@@ -70,6 +72,11 @@ namespace oisst {
     // other accessors
     boost::shared_ptr<const Geometry> geometry() const;
     const oops::Variables & variables() const { return vars_; }
+
+    // Serialize and deserialize (not needed by our project)
+    size_t serialSize() const override { return 0; }
+    void serialize(std::vector<double> &) const override {}
+    void deserialize(const std::vector<double> &, size_t &) override {}
 
    private:
     void print(std::ostream &) const;


### PR DESCRIPTION
A change in OOPS requires serializable interfaces to be added to `State`.
Dummy interfaces have been added so that the code compiles.  Similar to https://github.com/UMD-AOSC/OISSTv3/pull/5 we do not actually use the interfaces with our project, so they have not been fully implemented