### PR TITLE
replace boost::shared_ptr with std::shared_ptr

### DIFF
--- a/src/oisst/GetValues/GetValues.h
+++ b/src/oisst/GetValues/GetValues.h
@@ -12,8 +12,6 @@
 #include <ostream>
 #include <string>
 
-#include <boost/shared_ptr.hpp>
-
 #include "oops/util/ObjectCounter.h"
 #include "oops/util/Printable.h"
 

--- a/src/oisst/GetValues/LinearGetValues.h
+++ b/src/oisst/GetValues/LinearGetValues.h
@@ -12,8 +12,6 @@
 #include <ostream>
 #include <string>
 
-#include <boost/shared_ptr.hpp>
-
 #include "oops/util/ObjectCounter.h"
 #include "oops/util/Printable.h"
 

--- a/src/oisst/Increment/Increment.h
+++ b/src/oisst/Increment/Increment.h
@@ -16,8 +16,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
-
 #include "oops/base/GeneralizedDepartures.h"
 #include "oops/base/Variables.h"
 #include "oops/util/DateTime.h"
@@ -81,7 +79,7 @@ namespace oisst {
     void dirac(const eckit::Configuration &);
 
     // other accessors
-    boost::shared_ptr<const Geometry> geometry() const { return geom_; }
+    std::shared_ptr<const Geometry> geometry() const { return geom_; }
 
     // I/O
     void read(const eckit::Configuration &);
@@ -95,7 +93,7 @@ namespace oisst {
    private:
     void print(std::ostream &) const override;
 
-    boost::shared_ptr<const Geometry> geom_;
+    std::shared_ptr<const Geometry> geom_;
     util::DateTime time_;
     oops::Variables vars_;
   };

--- a/src/oisst/State/State.cc
+++ b/src/oisst/State/State.cc
@@ -108,7 +108,7 @@ namespace oisst {
 
 // ----------------------------------------------------------------------------
 
-  boost::shared_ptr<const Geometry> State::geometry() const {return geom_;}
+  std::shared_ptr<const Geometry> State::geometry() const {return geom_;}
 
 // ----------------------------------------------------------------------------
 

--- a/src/oisst/State/State.h
+++ b/src/oisst/State/State.h
@@ -13,8 +13,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
-
 #include "eckit/mpi/Comm.h"
 
 #include "oops/base/Variables.h"
@@ -70,7 +68,7 @@ namespace oisst {
     util::DateTime & validTime() { return time_; }
 
     // other accessors
-    boost::shared_ptr<const Geometry> geometry() const;
+    std::shared_ptr<const Geometry> geometry() const;
     const oops::Variables & variables() const { return vars_; }
 
     // Serialize and deserialize (not needed by our project)
@@ -81,7 +79,7 @@ namespace oisst {
    private:
     void print(std::ostream &) const;
 
-    boost::shared_ptr<const Geometry> geom_;
+    std::shared_ptr<const Geometry> geom_;
     oops::Variables vars_;
     util::DateTime time_;
   };


### PR DESCRIPTION
A recent change to OOPS has replaced `boost::shared_ptr` for geometry with `std::shared_ptr`