### PR TITLE
add test observations

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ endforeach()
 
 list( APPEND oisst_test_data
   Data/19850101_regridded_sst.nc
+  Data/obs_sst.nc
   )
 
 

--- a/test/Data/obs_sst.nc
+++ b/test/Data/obs_sst.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42dd448285de892b5c38e721d2c055dbece53a140d4421fe965fc9dee06c0fd3
+size 25172


### PR DESCRIPTION
Add a test sst observations file, the same one we are using for SOCA. It won't be used for anything until work is started on #19.
This is an observations file with just 200 locations, to allow for fast ctests. We'll deal with realistically sized observation sets later.

The date of the observations do not match that of the background file already in the repository, but that's okay, we can override the background date in the yaml files for the tests/applications that will use observations.

closes #16