### PR TITLE
add MPI support

### DIFF
--- a/src/oisst/Fields/Fields.cc
+++ b/src/oisst/Fields/Fields.cc
@@ -18,6 +18,7 @@
 #include "atlas/field.h"
 #include "atlas/option.h"
 
+#include "oops/mpi/mpi.h"
 #include "oops/util/abor1_cpp.h"
 #include "oops/util/Logger.h"
 #include "oops/util/missingValues.h"
@@ -119,6 +120,10 @@ namespace oisst {
       }
     }
 
+    // sum results across PEs
+    oops::mpi::world().allReduceInPlace(nValid, eckit::mpi::Operation::SUM);
+    oops::mpi::world().allReduceInPlace(s, eckit::mpi::Operation::SUM);
+
     if (nValid == 0)
       norm = 0.0;
     else
@@ -140,127 +145,145 @@ namespace oisst {
 // ----------------------------------------------------------------------------
 
   void Fields::read(const eckit::Configuration & conf) {
-    int time = 0, lon = 0, lat = 0;
-    std::string filename;
+    // create a global field valid on the root PE
+    atlas::Field globalSst = geom_->atlasFunctionSpace()->createField<double>(
+                         atlas::option::global());
 
-    auto fd = make_view<double, 1>(atlasFieldSet_->field(0));
-    const int size = geom_->atlasFunctionSpace()->size();
+    // following code block should execute on the root PE only
+    if ( globalSst.size() != 0 ) {
+      int time = 0, lon = 0, lat = 0;
+      std::string filename;
 
-    // get filename
-    if (!conf.get("filename", filename))
-      util::abor1_cpp("Increment::read(), Get filename failed.",
-        __FILE__, __LINE__);
+      auto fd = make_view<double, 1>(globalSst);
 
-    // open netCDF file
-    netCDF::NcFile file(filename.c_str(), netCDF::NcFile::read);
-    if (file.isNull())
-      util::abor1_cpp("Increment::read(), Create netCDF file failed.",
-        __FILE__, __LINE__);
+      // get filename
+      if (!conf.get("filename", filename))
+        util::abor1_cpp("Increment::read(), Get filename failed.",
+          __FILE__, __LINE__);
 
-    // get file dimensions
-    time = static_cast<int>(file.getDim("time").getSize());
-    lon  = static_cast<int>(file.getDim("lon").getSize());
-    lat  = static_cast<int>(file.getDim("lat").getSize());
-    if (time != 1 ||
-        lat != static_cast<int>(geom_->atlasFunctionSpace()->grid().ny()) ||
-        lon != static_cast<int>((((atlas::RegularLonLatGrid&)  // LC: no &?
-               (geom_->atlasFunctionSpace()->grid()))).nx()) ) {
-      util::abor1_cpp("Fields::read(), lat!=ny or lon!=nx",
-        __FILE__, __LINE__);
+      // open netCDF file
+      netCDF::NcFile file(filename.c_str(), netCDF::NcFile::read);
+      if (file.isNull())
+        util::abor1_cpp("Increment::read(), Create netCDF file failed.",
+          __FILE__, __LINE__);
+
+      // get file dimensions
+      time = static_cast<int>(file.getDim("time").getSize());
+      lon  = static_cast<int>(file.getDim("lon").getSize());
+      lat  = static_cast<int>(file.getDim("lat").getSize());
+      if (time != 1 ||
+          lat != static_cast<int>(geom_->atlasFunctionSpace()->grid().ny()) ||
+          lon != static_cast<int>((((atlas::RegularLonLatGrid&)  // LC: no &?
+                (geom_->atlasFunctionSpace()->grid()))).nx()) ) {
+        util::abor1_cpp("Fields::read(), lat!=ny or lon!=nx",
+          __FILE__, __LINE__);
+      }
+
+      // get sst data
+      netCDF::NcVar sstVar;
+      sstVar = file.getVar("sst");
+      if (sstVar.isNull())
+        util::abor1_cpp("Get sst var failed.", __FILE__, __LINE__);
+      float  sstData[lat][lon];
+      sstVar.getVar(sstData);  // if used double, read-in data would be wrong.
+
+      // mask missing values
+      const double epsilon = 1.0e-6;
+      const double missing_nc = -32768.0;
+      for (int j = 0; j < lat; j++)
+        for (int i = 0; i < lon; i++)
+          if (abs(sstData[j][i]-(missing_nc)) < epsilon)
+            sstData[j][i] = missing_;
+
+      // float to double
+      int idx = 0;
+      for (int j = 0; j < lat; j++)
+        for (int i = 0; i < lon; i++)
+          fd(idx++) = static_cast<double>(sstData[j][i]);
     }
 
-    // get sst data
-    netCDF::NcVar sstVar;
-    sstVar = file.getVar("sst");
-    if (sstVar.isNull())
-      util::abor1_cpp("Get sst var failed.", __FILE__, __LINE__);
-    float  sstData[lat][lon];
-    sstVar.getVar(sstData);  // if used double, read-in data would be wrong.
-
-    // mask missing values
-    const double epsilon = 1.0e-6;
-    const double missing_nc = -32768.0;
-    for (int j = 0; j < lat; j++)
-      for (int i = 0; i < lon; i++)
-        if (abs(sstData[j][i]-(missing_nc)) < epsilon)
-          sstData[j][i] = missing_;
-
-    // float to double
-    int idx = 0;
-    for (int j = 0; j < lat; j++)
-      for (int i = 0; i < lon; i++)
-        fd(idx++) = static_cast<double>(sstData[j][i]);
+    // scatter to the PEs
+    geom_->atlasFunctionSpace()->scatter(globalSst, atlasFieldSet_->field(0));
   }
 
 // ----------------------------------------------------------------------------
 
   void Fields::write(const eckit::Configuration & conf) const {
-    int lat, lon, time = 1;
-    std::string filename;
+    // gather from the PEs
+    atlas::Field globalSst = geom_->atlasFunctionSpace()->createField<double>(
+        atlas::option::global());
+    geom_->atlasFunctionSpace()->gather(atlasFieldSet_->field(0), globalSst);
 
-    // get filename
-    if (!conf.get("filename", filename))
-      util::abor1_cpp("Increment::write(), Get filename failed.",
-                      __FILE__, __LINE__);
-    else
-      oops::Log::info() << "Increment::write(), filename=" << filename
+    // The following code block should execute on the root PE only
+    if ( globalSst.size() != 0 ) {
+      int lat, lon, time = 1;
+      std::string filename;
+
+      // get filename
+      if (!conf.get("filename", filename))
+        util::abor1_cpp("Increment::write(), Get filename failed.",
+                        __FILE__, __LINE__);
+      else
+        oops::Log::info() << "Increment::write(), filename=" << filename
+                          << std::endl;
+
+      // create netCDF file
+      netCDF::NcFile file(filename.c_str(), netCDF::NcFile::replace);
+      if (file.isNull())
+        util::abor1_cpp("Increment::write(), Create netCDF file failed.",
+                        __FILE__, __LINE__);
+
+      // define dims
+      lat = geom_->atlasFunctionSpace()->grid().ny();
+      lon = ((atlas::RegularLonLatGrid)
+             (geom_->atlasFunctionSpace()->grid())).nx();
+
+      // unlimited dim if without size parameter, then it'll be 0,
+      // what about the size?
+      netCDF::NcDim timeDim = file.addDim("time", 1);
+      netCDF::NcDim latDim  = file.addDim("lat" , lat);
+      netCDF::NcDim lonDim  = file.addDim("lon" , lon);
+      if (timeDim.isNull() || latDim.isNull() || lonDim.isNull())
+        util::abor1_cpp("Increment::write(), Define dims failed.",
+                        __FILE__, __LINE__);
+
+      std::vector<netCDF::NcDim> dims;
+      dims.push_back(timeDim);
+      dims.push_back(latDim);
+      dims.push_back(lonDim);
+
+      // Lignag: define coordinate vars "lat" and "lon"
+      // Ligang: define units atts for coordinate vars
+
+      // inside OISSTv3/JEDI, use double, read/write use float
+      // to make it consistent with the netCDF files.
+      netCDF::NcVar sstVar = file.addVar(std::string("sst"),
+                                        netCDF::ncFloat, dims);
+
+      // define units atts for data vars
+      const float fillvalue = -32768.0;
+      sstVar.putAtt("units", "K");
+      sstVar.putAtt("_FillValue", netCDF::NcFloat(), fillvalue);
+      sstVar.putAtt("missing_value", netCDF::NcFloat(), fillvalue);
+
+      // write data to the file
+      auto fd = make_view<double, 1>(globalSst);
+      float sstData[time][lat][lon];
+      int idx = 0;
+      for (int j = 0; j < lat; j++)
+        for (int i = 0; i < lon; i++) {
+          if (fd(idx) == missing_)
+            sstData[0][j][i] = fillvalue;
+          else
+            sstData[0][j][i] = static_cast<float>(fd(idx));
+          idx++;
+        }
+
+      sstVar.putVar(sstData);
+
+      oops::Log::info() << "Fields::write(), Successfully write data to file!"
                         << std::endl;
-
-    // create netCDF file
-    netCDF::NcFile file(filename.c_str(), netCDF::NcFile::replace);
-    if (file.isNull())
-      util::abor1_cpp("Increment::write(), Create netCDF file failed.",
-                      __FILE__, __LINE__);
-
-    // define dims
-    lat = geom_->atlasFunctionSpace()->grid().ny();
-    lon =((atlas::RegularLonLatGrid)(geom_->atlasFunctionSpace()->grid())).nx();
-
-    // unlimited dim if without size parameter, then it'll be 0,
-    // what about the size?
-    netCDF::NcDim timeDim = file.addDim("time", 1);
-    netCDF::NcDim latDim  = file.addDim("lat" , lat);
-    netCDF::NcDim lonDim  = file.addDim("lon" , lon);
-    if (timeDim.isNull() || latDim.isNull() || lonDim.isNull())
-      util::abor1_cpp("Increment::write(), Define dims failed.",
-                      __FILE__, __LINE__);
-
-    std::vector<netCDF::NcDim> dims;
-    dims.push_back(timeDim);
-    dims.push_back(latDim);
-    dims.push_back(lonDim);
-
-    // Lignag: define coordinate vars "lat" and "lon"
-    // Ligang: define units atts for coordinate vars
-
-    // inside OISSTv3/JEDI, use double, read/write use float
-    // to make it consistent with the netCDF files.
-    netCDF::NcVar sstVar = file.addVar(std::string("sst"),
-                                       netCDF::ncFloat, dims);
-
-    // define units atts for data vars
-    const float fillvalue = -32768.0;
-    sstVar.putAtt("units", "K");
-    sstVar.putAtt("_FillValue", netCDF::NcFloat(), fillvalue);
-    sstVar.putAtt("missing_value", netCDF::NcFloat(), fillvalue);
-
-    // write data to the file
-    auto fd = make_view<double, 1>(atlasFieldSet_->field(0));
-    float sstData[time][lat][lon];
-    int idx = 0;
-    for (int j = 0; j < lat; j++)
-      for (int i = 0; i < lon; i++) {
-        if (fd(idx) == missing_)
-          sstData[0][j][i] = fillvalue;
-        else
-          sstData[0][j][i] = static_cast<float>(fd(idx));
-        idx++;
-      }
-
-    sstVar.putVar(sstData);
-
-    oops::Log::info() << "Fields::write(), Successfully write data to file!"
-                      << std::endl;
+    }
   }
 
 // ----------------------------------------------------------------------------
@@ -294,9 +317,15 @@ namespace oisst {
         nValid++;
       }
 
+    // gather results across PEs
+    oops::mpi::world().allReduceInPlace(nValid, eckit::mpi::Operation::SUM);
+    oops::mpi::world().allReduceInPlace(sum, eckit::mpi::Operation::SUM);
+    oops::mpi::world().allReduceInPlace(min, eckit::mpi::Operation::MIN);
+    oops::mpi::world().allReduceInPlace(max, eckit::mpi::Operation::MAX);
+
     if (nValid == 0) {
       mean = 0.0;
-      oops::Log::debug() << "State::print(), nValid == 0!" << std::endl;
+      oops::Log::debug() << "Field::print(), nValid == 0!" << std::endl;
     } else {
       mean = sum / (1.0*nValid);
     }

--- a/src/oisst/Increment/Increment.cc
+++ b/src/oisst/Increment/Increment.cc
@@ -17,6 +17,7 @@
 #include "atlas/array.h"
 
 #include "oops/base/Variables.h"
+#include "oops/mpi/mpi.h"
 #include "oops/util/abor1_cpp.h"
 #include "oops/util/Logger.h"
 #include "oops/util/Random.h"
@@ -137,6 +138,9 @@ namespace oisst {
     // Ligang: will be updated with missing_value process!
     for (int i = 0; i < size; i++)
       dp += fd(i)*fd_other(i);
+
+    // sum results across PEs
+    oops::mpi::world().allReduceInPlace(dp, eckit::mpi::Operation::SUM);
 
     return dp;
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,8 @@ foreach(FILENAME ${oisst_test_data})
     ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} )
 endforeach()
 
+# number of PEs to use for MPI enabled tests.
+set( MPI_PES 2)
 
 #================================================================================
 # Tests of class interfaces
@@ -44,52 +46,61 @@ endforeach()
      TARGET  test_oisst_geometry
      SOURCES executables/TestGeometry.cc
      ARGS    testinput/geometry.yml
+     MPI     ${MPI_PES}
      LIBS    oisst )
 
    ecbuild_add_test(
      TARGET  test_oisst_state
      SOURCES executables/TestState.cc
      ARGS    testinput/state.yml
+     MPI     ${MPI_PES}
      LIBS    oisst )
 
    ecbuild_add_test(
      TARGET  test_oisst_increment
      SOURCES executables/TestIncrement.cc
      ARGS    testinput/increment.yml
+     MPI     ${MPI_PES}
      LIBS    oisst )
 
 #  ecbuild_add_test(
 #    TARGET  test_oisst_modelauxcontrol
 #    SOURCES executables/TestModelAuxControl.cc
 #    ARGS    testinput/modelaux.yml
+#    MPI     ${MPI_PES}
 #    LIBS    oisst )
 
 #  ecbuild_add_test(
 #    TARGET  test_oisst_getvalues
 #    SOURCES executables/TestGetValues.cc
 #    ARGS    testinput/getvalues.yml
+#    MPI     ${MPI_PES}
 #    LIBS    oisst )
 
 #  ecbuild_add_test(
 #    TARGET  test_oisst_lineargetvalues
 #    SOURCES executables/TestLinearGetValues.cc
 #    ARGS    testinput/lineargetvalues.yml
+#    MPI     ${MPI_PES}
 #    LIBS    oisst )
 
 #  ecbuild_add_test(
 #    TARGET  test_oisst_errorcovariance
 #    SOURCES executables/TestErrorCovariance.cc
 #    ARGS    testinput/errorcovariance.yml
+#    MPI     ${MPI_PES}
 #    LIBS    oisst )
 
 #  ecbuild_add_test(
 #    TARGET  test_oisst_modelauxcovariance
 #    SOURCES executables/TestModelAuxCovariance.cc
 #    ARGS    testinput/modelaux.yml
+#    MPI     ${MPI_PES}
 #    LIBS    oisst )
 
 #  ecbuild_add_test(
 #    TARGET  test_oisst_modelauxincrement
 #    SOURCES executables/TestModelAuxIncrement.cc
 #    ARGS    testinput/modelaux.yml
+#    MPI     ${MPI_PES}
 #    LIBS    oisst )

--- a/test/testinput/increment.yml
+++ b/test/testinput/increment.yml
@@ -8,4 +8,4 @@ inc variables: [sea_surface_temperature]
 
 increment test:
   date: 1985-01-01T12:00:00Z
-  tolerance: 1e-6
+  tolerance: 1e-12


### PR DESCRIPTION
It occurred to me this morning that all the tests we were doing were not parallelized (my fault for forgetting to put the MPI commands in the `test/CMakeLists.txt`, oops!).  This PR does the following

- all the tests now run with 2 PEs to test the parallelization
- the `Fields::read()` / `Fields::write()` methods now only read/write the state on the root PE and then use `atlasFunctionSpace()->scatter()` and `->gather()` to distribute to all the PEs
- `norm()`, `dot_product_with()`, and `print()` are global operations, and so need to use MPI calls to collect the final results

Does not change the behavior of the code if running with just 1 PE. Makes the code work with >1 PE (it was crashing before)