### PR TITLE
add missing ModelAux stubs

### DIFF
--- a/src/oisst/ModelAux/ModelAuxControl.h
+++ b/src/oisst/ModelAux/ModelAuxControl.h
@@ -39,8 +39,13 @@ namespace oisst {
     ModelAuxControl(const ModelAuxControl &, const bool);
     ~ModelAuxControl();
 
+    // I/O
+    void read(const eckit::Configuration &) {}
+    void write(const eckit::Configuration &) const {}
+
     // math operators
     ModelAuxControl & operator +=(const ModelAuxIncrement &);
+    double norm() const {return 0.0;}
 
    private:
     void print(std::ostream & os) const;

--- a/src/oisst/ModelAux/ModelAuxIncrement.h
+++ b/src/oisst/ModelAux/ModelAuxIncrement.h
@@ -52,6 +52,10 @@ namespace oisst {
     double norm() const;
     void zero();
 
+    // I/O
+    void read(const eckit::Configuration &) {}
+    void write(const eckit::Configuration &) const {}
+
     // serialize and deserialize
     size_t serialSize() const override {return 0;}
     void serialize(std::vector<double> &) const override {}


### PR DESCRIPTION
This PR adds several of the `ModelAux..` empty methods that I somehow forgot to add initially. This wasn't a problem until yesterday, when an oops PR requires `ModelAuxIncrement::write()` to be present. Since we don't need any of the `ModelAux...` functionality, these will remain empty stubs in our code.