### PR TITLE
Implement GetValues

### DIFF
--- a/src/umdsst/GetValues/CMakeLists.txt
+++ b/src/umdsst/GetValues/CMakeLists.txt
@@ -3,4 +3,10 @@ umdsst_target_sources(
     GetValues.h
     LinearGetValues.cc
     LinearGetValues.h
+
+    # Note: these are temporary, and should be removed once
+    # Locations and GeoVaLs have a proper c++ interface
+    LocationsWrapper.h
+    LocationsWrapper.f90
+    GeoVaLsWrapper.h
 )

--- a/src/umdsst/GetValues/CMakeLists.txt
+++ b/src/umdsst/GetValues/CMakeLists.txt
@@ -9,4 +9,5 @@ umdsst_target_sources(
     LocationsWrapper.h
     LocationsWrapper.f90
     GeoVaLsWrapper.h
+    GeoVaLsWrapper.f90
 )

--- a/src/umdsst/GetValues/GeoVaLsWrapper.f90
+++ b/src/umdsst/GetValues/GeoVaLsWrapper.f90
@@ -1,0 +1,62 @@
+module geovals_wrapper
+
+use atlas_module
+use iso_c_binding
+use kinds
+use ufo_geovals_mod_c, only: ufo_geovals_registry
+use ufo_geovals_mod, only: ufo_geovals
+use ufo_locs_mod_c, only: ufo_locs_registry
+use ufo_locs_mod, only: ufo_locs, ufo_locs_time_mask
+use datetime_mod, only: datetime, c_f_datetime
+
+implicit none
+
+contains
+
+subroutine geovals_wrapper_fill( c_key_geovals, c_key_locs, c_t1, c_t2, c_field) &
+       bind(c, name="geovals_wrapper_fill_f90")
+    integer(c_int),  intent(inout) :: c_key_geovals
+    integer(c_int),  intent(inout) :: c_key_locs
+    type(c_ptr),        intent(in) :: c_t1
+    type(c_ptr),        intent(in) :: c_t2    
+    type(c_ptr), value, intent(in) :: c_field
+
+    type(ufo_geovals), pointer :: geovals
+    type(ufo_locs),    pointer :: locs
+    type(atlas_field)          :: field
+    type(datetime)             :: t1, t2
+    real(kind_real),    pointer:: field_data(:,:)
+    logical, allocatable :: time_mask(:)
+
+    integer :: ivar, nval, i
+
+    ! get fortran version fo the passed in C arguments
+    call ufo_geovals_registry%get(c_key_geovals, geovals)
+    call ufo_locs_registry%get(c_key_locs, locs)
+    field = atlas_field(c_field)
+    call field%data(field_data)
+    call c_f_datetime(c_t1, t1)
+    call c_f_datetime(c_t2, t2)
+  
+    ! calculate time mask
+    call ufo_locs_time_mask(locs, t1, t2, time_mask)
+
+    ! initialize geovals
+    ivar=1
+    nval=1
+    if (.not. geovals%linit) then
+        geovals%geovals(ivar)%nval = nval
+        allocate(geovals%geovals(ivar)%vals(nval, geovals%geovals(ivar)%nlocs))
+        geovals%geovals(ivar)%vals = 0.0
+        geovals%linit = .true.
+    end if
+
+    ! fill the geovals, obeying the time masking
+    do i=1, size(time_mask)
+        if (time_mask(i)) then
+            geovals%geovals(ivar)%vals(:,i) = field_data(:,i)
+        end if
+    end do
+end subroutine
+
+end module

--- a/src/umdsst/GetValues/GeoVaLsWrapper.h
+++ b/src/umdsst/GetValues/GeoVaLsWrapper.h
@@ -11,14 +11,31 @@
 #include "ufo/GeoVaLs.h"
 
 namespace umdsst {
+
+  extern "C" {
+    void geovals_wrapper_fill_f90(const int &, const int &,
+                                  const util::DateTime **,
+                                  const util::DateTime **,
+                                  const atlas::field::FieldImpl *);
+  }
+
   class GeoVaLsWrapper {
    public:
-    explicit GeoVaLsWrapper(const ufo::GeoVaLs & geovals)
-     : geovals_(geovals)
-    {}
+    explicit GeoVaLsWrapper(const ufo::GeoVaLs & geovals,
+                            const ufo::Locations & locs)
+     : geovals_(&geovals), locs_(&locs) {}
 
+    void fill(const util::DateTime & t1,
+              const util::DateTime & t2,
+              const atlas::Field & fld) {
+      const util::DateTime * t1p = &t1;
+      const util::DateTime * t2p = &t2;
+      geovals_wrapper_fill_f90(geovals_->toFortran(), locs_->toFortran(),
+                               &t1p, &t2p, fld.get());
+    }
    private:
-     ufo::GeoVaLs geovals_;
+     const ufo::GeoVaLs *geovals_;
+     const ufo::Locations *locs_;
   };
 }  // namespace umdsst
 

--- a/src/umdsst/GetValues/GeoVaLsWrapper.h
+++ b/src/umdsst/GetValues/GeoVaLsWrapper.h
@@ -1,0 +1,25 @@
+/*
+ * (C) Copyright 2020-2020 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef UMDSST_GETVALUES_GEOVALSWRAPPER_H_
+#define UMDSST_GETVALUES_GEOVALSWRAPPER_H_
+
+#include "ufo/GeoVaLs.h"
+
+namespace umdsst {
+  class GeoVaLsWrapper {
+   public:
+    explicit GeoVaLsWrapper(const ufo::GeoVaLs & geovals)
+     : geovals_(geovals)
+    {}
+
+   private:
+     ufo::GeoVaLs geovals_;
+  };
+}  // namespace umdsst
+
+#endif  // UMDSST_GETVALUES_GEOVALSWRAPPER_H_

--- a/src/umdsst/GetValues/GetValues.cc
+++ b/src/umdsst/GetValues/GetValues.cc
@@ -11,6 +11,7 @@
 
 #include "eckit/config/Configuration.h"
 
+#include "oops/generic/InterpolatorUnstructured.h"
 #include "oops/base/Variables.h"
 #include "oops/util/abor1_cpp.h"
 
@@ -24,16 +25,14 @@ namespace umdsst {
   GetValues::GetValues(const Geometry & geom,
                        const ufo::Locations & locs)
     : geom_(new Geometry(geom)), locs_(locs) {
-    util::abor1_cpp("GetValues::GetValues() needs to be implemented.",
-                    __FILE__, __LINE__);
+    oops::InterpolatorUnstructured interpolator(eckit::LocalConfiguration(),
+                                                *geom_->atlasFunctionSpace(),
+                                                locs_.atlasFunctionSpace());
   }
 
 // -----------------------------------------------------------------------------
 
-  GetValues::~GetValues() {
-    util::abor1_cpp("GetValues::~GetValues() needs to be implemented.",
-                     __FILE__, __LINE__);
-  }
+  GetValues::~GetValues() { }
 
 // ----------------------------------------------------------------------------
 
@@ -41,8 +40,6 @@ namespace umdsst {
                               const util::DateTime & t1,
                               const util::DateTime & t2,
                               ufo::GeoVaLs & geovals) const {
-    util::abor1_cpp("GetValues::fillGeoVaLs() needs to be implemented.",
-                     __FILE__, __LINE__);
   }
 
 // ----------------------------------------------------------------------------

--- a/src/umdsst/GetValues/GetValues.h
+++ b/src/umdsst/GetValues/GetValues.h
@@ -12,20 +12,28 @@
 #include <ostream>
 #include <string>
 
+#include "umdsst/GetValues/LocationsWrapper.h"
+#include "umdsst/GetValues/GeoVaLsWrapper.h"
+
 #include "oops/util/ObjectCounter.h"
 #include "oops/util/Printable.h"
 
 #include "ufo/Locations.h"
 
 // forward declarations
-namespace ufo {
-  class GeoVaLs;
-  class Locations;
-}
 namespace umdsst {
   class Geometry;
   class State;
 }
+
+namespace oops {
+  class InterpolatorUnstructured;
+}
+namespace ufo {
+  class GeoVaLs;
+  class Locations;
+}
+
 
 // ----------------------------------------------------------------------------
 
@@ -50,8 +58,9 @@ namespace umdsst {
    private:
     void print(std::ostream &) const;
 
+    std::unique_ptr<oops::InterpolatorUnstructured> interpolator_;
     std::shared_ptr<const Geometry> geom_;
-    ufo::Locations locs_;
+    LocationsWrapper locs_;
   };
 }  // namespace umdsst
 

--- a/src/umdsst/GetValues/LocationsWrapper.f90
+++ b/src/umdsst/GetValues/LocationsWrapper.f90
@@ -1,0 +1,36 @@
+module locations_wrapper
+
+use atlas_module
+use iso_c_binding
+use kinds
+use ufo_locs_mod_c, only: ufo_locs_registry
+use ufo_locs_mod, only: ufo_locs
+
+implicit none
+
+contains
+
+subroutine locations_wrapper_fill( c_key_loc, c_field) bind(c, name="locations_wrapper_fill_f90")
+    integer(c_int),  intent(inout) :: c_key_loc
+    type(c_ptr), value, intent(in) :: c_field
+
+    type(ufo_locs),     pointer :: locs
+    type(atlas_field)           :: field
+    
+    real(kind_real),    pointer :: lonlat(:,:)
+    integer :: i
+
+    ! get fortran version of the passed in C arguments
+    call ufo_locs_registry%get(c_key_loc, locs)
+    field = atlas_field(c_field)
+    call field%data(lonlat)
+    
+    ! fill in the lat/lon
+    do i = 1, size(lonlat, dim=2)
+        lonlat(1,i) = locs%lon(i)
+        lonlat(2,i) = locs%lat(i)
+    end do
+
+end subroutine
+
+end module

--- a/src/umdsst/GetValues/LocationsWrapper.h
+++ b/src/umdsst/GetValues/LocationsWrapper.h
@@ -37,6 +37,8 @@ namespace umdsst {
         return *functionSpace_;
     }
 
+    const ufo::Locations & locs() const { return locs_; }
+
    private:
      const ufo::Locations locs_;
      std::unique_ptr<atlas::functionspace::PointCloud> functionSpace_;

--- a/src/umdsst/GetValues/LocationsWrapper.h
+++ b/src/umdsst/GetValues/LocationsWrapper.h
@@ -1,0 +1,46 @@
+/*
+ * (C) Copyright 2020-2020 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef UMDSST_GETVALUES_LOCATIONSWRAPPER_H_
+#define UMDSST_GETVALUES_LOCATIONSWRAPPER_H_
+
+#include <memory>
+#include <vector>
+
+#include "atlas/array.h"
+#include "atlas/functionspace.h"
+
+#include "ufo/Locations.h"
+
+namespace umdsst {
+
+  extern "C" {
+    void locations_wrapper_fill_f90(const int &,
+                                    const atlas::field::FieldImpl *);
+  }
+
+  class LocationsWrapper {
+   public:
+    explicit LocationsWrapper(const ufo::Locations & locs) : locs_(locs) {
+      atlas::Field field("lonlat",
+                         atlas::array::make_datatype<double>(),
+                         atlas::array::make_shape(locs.nobs(), 2) );
+      locations_wrapper_fill_f90(locs_.toFortran(), field.get());
+      functionSpace_.reset(new atlas::functionspace::PointCloud(field));
+    }
+
+    const atlas::FunctionSpace & atlasFunctionSpace() const {
+        return *functionSpace_;
+    }
+
+   private:
+     const ufo::Locations locs_;
+     std::unique_ptr<atlas::functionspace::PointCloud> functionSpace_;
+  };
+}  // namespace umdsst
+
+#endif  // UMDSST_GETVALUES_LOCATIONSWRAPPER_H_

--- a/src/umdsst/Increment/Increment.cc
+++ b/src/umdsst/Increment/Increment.cc
@@ -75,10 +75,10 @@ namespace umdsst {
     const int size = geom_->atlasFunctionSpace()->size();
 
     for (int i = 0; i < vars_.size(); i++) {
-      auto fd       = make_view<double, 1>(atlasFieldSet_->field(0));
-      auto fd_other = make_view<double, 1>(other.atlasFieldSet()->field(0));
+      auto fd       = make_view<double, 2>(atlasFieldSet_->field(0));
+      auto fd_other = make_view<double, 2>(other.atlasFieldSet()->field(0));
       for (int j = 0; j < size; j++)
-        fd(j) -= fd_other(j);
+        fd(j, 0) -= fd_other(j, 0);
     }
 
     return *this;
@@ -94,11 +94,11 @@ namespace umdsst {
 // ----------------------------------------------------------------------------
 
   Increment & Increment::operator *=(const double &zz) {
-    auto fd       = make_view<double, 1>(atlasFieldSet_->field(0));
+    auto fd       = make_view<double, 2>(atlasFieldSet_->field(0));
     const int size = geom_->atlasFunctionSpace()->size();
 
     for (int j = 0; j < size; j++)
-      fd(j) *= zz;
+      fd(j, 0) *= zz;
 
     return *this;
   }
@@ -116,28 +116,28 @@ namespace umdsst {
 // ----------------------------------------------------------------------------
 
   void Increment::diff(const State & x1, const State & x2) {
-    auto fd = make_view<double, 1>(atlasFieldSet_->field(0));
-    auto fd_x1 = make_view<double, 1>(x1.atlasFieldSet()->field(0));
-    auto fd_x2 = make_view<double, 1>(x2.atlasFieldSet()->field(0));
+    auto fd = make_view<double, 2>(atlasFieldSet_->field(0));
+    auto fd_x1 = make_view<double, 2>(x1.atlasFieldSet()->field(0));
+    auto fd_x2 = make_view<double, 2>(x2.atlasFieldSet()->field(0));
 
     const int size = geom_->atlasFunctionSpace()->size();
 
     for (int i = 0; i < size; i++)
-      fd(i) = fd_x1(i) - fd_x2(i);
+      fd(i, 0) = fd_x1(i, 0) - fd_x2(i, 0);
   }
 
 // ----------------------------------------------------------------------------
 
   double Increment::dot_product_with(const Increment &other) const {
-    auto fd = make_view<double, 1>(atlasFieldSet_->field(0));
-    auto fd_other = make_view<double, 1>(other.atlasFieldSet()->field(0));
+    auto fd = make_view<double, 2>(atlasFieldSet_->field(0));
+    auto fd_other = make_view<double, 2>(other.atlasFieldSet()->field(0));
 
     const int size = geom_->atlasFunctionSpace()->size();
     double dp = 0.0;
 
     // Ligang: will be updated with missing_value process!
     for (int i = 0; i < size; i++)
-      dp += fd(i)*fd_other(i);
+      dp += fd(i, 0)*fd_other(i, 0);
 
     // sum results across PEs
     oops::mpi::world().allReduceInPlace(dp, eckit::mpi::Operation::SUM);
@@ -148,31 +148,31 @@ namespace umdsst {
 // ----------------------------------------------------------------------------
 
   void Increment::ones() {
-    auto fd = make_view<double, 1>(atlasFieldSet_->field(0));
+    auto fd = make_view<double, 2>(atlasFieldSet_->field(0));
     fd.assign(1.0);
   }
 
 // ----------------------------------------------------------------------------
 
   void Increment::random() {
-    auto fd = make_view<double, 1>(atlasFieldSet_->field(0));
+    auto fd = make_view<double, 2>(atlasFieldSet_->field(0));
     const int size = geom_->atlasFunctionSpace()->size();
 
     util::NormalDistribution<double> x(size, 0, 1.0, 1);
 
     for (int i = 0; i < size; i++)
-      fd(i) = x[i];
+      fd(i, 0) = x[i];
   }
 
 // ----------------------------------------------------------------------------
 
   void Increment::schur_product_with(const Increment &rhs ) {
-    auto fd = make_view<double, 1>(atlasFieldSet_->field(0));
-    auto fd_rhs = make_view<double, 1>(rhs.atlasFieldSet()->field(0));
+    auto fd = make_view<double, 2>(atlasFieldSet_->field(0));
+    auto fd_rhs = make_view<double, 2>(rhs.atlasFieldSet()->field(0));
 
     const int size = geom_->atlasFunctionSpace()->size();
     for (int i = 0; i < size; i++)
-      fd(i) *= fd_rhs(i);
+      fd(i, 0) *= fd_rhs(i, 0);
   }
 
 // ----------------------------------------------------------------------------
@@ -210,10 +210,10 @@ namespace umdsst {
     for (int i = 0; i < dir_size; i++)
       ASSERT(ixdir[i] < nx && iydir[i] < ny);
 
-    auto fd = make_view<double, 1>(atlasFieldSet_->field(0));
+    auto fd = make_view<double, 2>(atlasFieldSet_->field(0));
     for (int i = 0; i < dir_size; i++) {
       int idx = ixdir[i] + iydir[i]*nx;
-      fd(idx) = 1.0;
+      fd(idx, 0) = 1.0;
     }
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,12 +70,12 @@ set( MPI_PES 2)
 #    MPI     ${MPI_PES}
 #    LIBS    umdsst )
 
-#  ecbuild_add_test(
-#    TARGET  test_umdsst_getvalues
-#    SOURCES executables/TestGetValues.cc
-#    ARGS    testinput/getvalues.yml
-#    MPI     ${MPI_PES}
-#    LIBS    umdsst )
+  ecbuild_add_test(
+    TARGET  test_umdsst_getvalues
+    SOURCES executables/TestGetValues.cc
+    ARGS    testinput/getvalues.yml
+    MPI     ${MPI_PES}
+    LIBS    umdsst )
 
 #  ecbuild_add_test(
 #    TARGET  test_umdsst_lineargetvalues

--- a/test/testinput/getvalues.yml
+++ b/test/testinput/getvalues.yml
@@ -26,6 +26,6 @@ getvalues test:
     date: 2018-04-15T00:00:00Z
     filename: Data/19850101_regridded_sst.nc
     state variables: *state_vars
-  # interpolation tolerance: 1e-10
+  interpolation tolerance: 1e-10
 
 linear getvalues test:

--- a/test/testinput/getvalues.yml
+++ b/test/testinput/getvalues.yml
@@ -1,7 +1,10 @@
 geometry:
-  # insert other model specific things here
+  grid: S360x180
+  domain:
+    type: global
+    west: -180
 
-state variables: &state_vars [var1, var2]
+state variables: &state_vars [sea_surface_temperature]
 
 locations:
   window begin: 2018-04-15T00:00:00Z
@@ -16,12 +19,13 @@ locations:
         lat2: 90
         lon1: 0
         lon2: 360
-      obs errors: [1.0, 1.0]
+      obs errors: [1.0]
 
 getvalues test:
   state generate:
     date: 2018-04-15T00:00:00Z
+    filename: Data/19850101_regridded_sst.nc
     state variables: *state_vars
-  interpolation tolerance: 1e-10
+  # interpolation tolerance: 1e-10
 
 linear getvalues test:


### PR DESCRIPTION
implements the `GetValues` class. closes #18 
(@loganchen39 sorry, i know you were going to do this, but the majority of the work was in creating the C++/Fortran code for `Locations` and `GeoVaLs` that I said I would do.)

in order to implement `GetValues` I had to:
1. change all the fields to use `atlas::options:levels(1)` so that the arrays are rank 2. This is because the interpolation routines in oops assume that multilevel fields are possible and so use rank 2 arrays everywhere.
2. Implement  `GeoVaLsWrapper` and `LocationsWrapper` classes that provide the missing C++ functionality of the `GeoVaLs` and `Locations` classes that is currently only available on the Fortran side. Once these classes are rewritten to better support C++ by the JEDI team (next month??) we'll remove those wrapper classes.

Interpolation is done by the oops `InterpolatorUnstructured` class. This interpolation does not yet support masks, I'll add a separate issue to remind us to address this