### PR TITLE
add hofx_nomodel test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,24 +1,17 @@
 list( APPEND umdsst_test_input
-  testinput/geometry.yml
   testinput/errorcovariance.yml
+  testinput/geometry.yml
   testinput/getvalues.yml
-  testinput/lineargetvalues.yml
-  testinput/linearmodel.yml
+  testinput/hofx_nomodel.yml
   testinput/increment.yml
-  testinput/model.yml
+  testinput/lineargetvalues.yml
   testinput/modelaux.yml
   testinput/state.yml
   )
 
-
-# link the input files for the tests
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testinput)
-foreach(FILENAME ${umdsst_test_input})
-  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-    ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
-    ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} )
-endforeach()
-
+list( APPEND umdsst_test_ref
+  testref/hofx_nomodel.ref
+  )
 
 list( APPEND umdsst_test_data
   Data/19850101_regridded_sst.nc
@@ -26,9 +19,18 @@ list( APPEND umdsst_test_data
   )
 
 
-# link the input files for the tests
+# create necessary directories
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testinput)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testref)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testoutput)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Data)
-foreach(FILENAME ${umdsst_test_data})
+
+# link the input files for the tests
+foreach(FILENAME
+  ${umdsst_test_input}
+  ${umdsst_test_ref}
+  ${umdsst_test_data}
+  )
   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
     ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
     ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} )
@@ -36,6 +38,67 @@ endforeach()
 
 # number of PEs to use for MPI enabled tests.
 set( MPI_PES 2)
+
+
+#-------------------------------------------------------------------------------
+# The following is a wrapper to simplify the generation of tests of the umdsst
+# executables.
+function(umdsst_exe_test)
+  # parse the passed arguments
+  set(prefix     ARG)
+  set(novals     NOCOMPARE NOTRAPFPE)
+  set(singlevals NAME EXE CFG)
+  set(multivals  TEST_DEPENDS TOL)
+  cmake_parse_arguments(${prefix}
+                        "${novals}" "${singlevals}" "${multivals}"
+                        ${ARGN})
+
+  # set the tolerances to defaults if none given, or if we want to override
+  IF(NOT ARG_TOL)
+    SET(ARG_TOL "1.0e-12;0")
+  ENDIF()
+  LIST(GET ARG_TOL 0 TOL_F)
+  LIST(GET ARG_TOL 1 TOL_I)
+
+  # determine if floating point error trapping should be set
+  if (DEFINED ENV{OOPS_TRAPFPE})
+    set (TRAPFPE_ENV $ENV{OOPS_TRAPFPE})
+  elseif( ARG_NOTRAPFPE)
+    set ( TRAPFPE_ENV "OOPS_TRAPFPE=0")
+  else()
+    set ( TRAPFPE_ENV "OOPS_TRAPFPE=1")
+  endif()
+
+  # determine the default config file name
+  if ( ARG_CFG )
+    set ( CONFIG_FILE testinput/${ARG_CFG} )
+  else()
+    set ( CONFIG_FILE testinput/${ARG_NAME}.yml )
+  endif()
+
+  # find the MPI command
+  set(MPI_CMD "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPI_PES}")
+
+  # find compare.py provided by oops
+  find_file(COMPARE_BIN oops_compare.py HINTS ${oops_BINDIR})
+
+  # add the test
+  ecbuild_add_test( TARGET  test_umdsst_${ARG_NAME}
+                    TYPE    SCRIPT
+                    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_wrapper.sh"
+                    ARGS    "${CMAKE_BINARY_DIR}/bin/${ARG_EXE}"
+                            ${CONFIG_FILE}
+                    ENVIRONMENT
+                            ${TRAPFPE_ENV}
+                            COMPARE_SCRIPT=${COMPARE_BIN}
+                            COMPARE_TESTNAME=${ARG_NAME}
+                            COMPARE_TOL_F=${TOL_F}
+                            COMPARE_TOL_I=${TOL_I}
+                            MPI_CMD=${MPI_CMD}
+                            SKIP_COMPARE=${ARG_NOCOMPARE}
+                    DEPENDS ${ARGE_EXE}
+                    TEST_DEPENDS ${ARG_TEST_DEPENDS})
+endfunction()
 
 #================================================================================
 # Tests of class interfaces
@@ -104,3 +167,22 @@ set( MPI_PES 2)
 #    ARGS    testinput/modelaux.yml
 #    MPI     ${MPI_PES}
 #    LIBS    umdsst )
+
+
+#================================================================================
+# Test of executables
+#================================================================================
+
+umdsst_exe_test( NAME hofx_nomodel
+                 EXE  umdsst_hofx_nomodel.x )
+
+# umdsst_exe_test( NAME staticbinit
+#                  EXE  umdsst_staticbinit.x )
+
+# umdsst_exe_test( NAME dirac
+#                  EXE  umdsst_dirac.x
+#                  TEST_DEPENDS test_umdsst_staticbinit )
+
+# umdsst_exe_test( NAME var
+#                  EXE  umdsst_var.x
+#                  TEST_DEPENDS test_umdsst_staticbinit )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,9 +61,7 @@ function(umdsst_exe_test)
   LIST(GET ARG_TOL 1 TOL_I)
 
   # determine if floating point error trapping should be set
-  if (DEFINED ENV{OOPS_TRAPFPE})
-    set (TRAPFPE_ENV $ENV{OOPS_TRAPFPE})
-  elseif( ARG_NOTRAPFPE)
+  if( ARG_NOTRAPFPE)
     set ( TRAPFPE_ENV "OOPS_TRAPFPE=0")
   else()
     set ( TRAPFPE_ENV "OOPS_TRAPFPE=1")

--- a/test/test_wrapper.sh
+++ b/test/test_wrapper.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# simple script to combine into a single ctest the 1) running of executable and
+# 2)comparing its answers to reference answers.
+
+# run the executable
+echo ""
+echo "==============================================================================="
+echo "Running test executable"
+echo "==============================================================================="
+${MPI_CMD} $1 $2 testoutput/${COMPARE_TESTNAME}.log
+e=$?
+if [[ "$e" -gt 0 ]]; then
+    echo -e "Failed to run executable. Error code: $e \n"
+    exit $e
+fi
+
+# run compare, if needed
+if [[ "$SKIP_COMPARE" == "FALSE" ]]; then
+    echo ""
+    echo "==============================================================================="
+    echo "Running compare script"
+    echo "==============================================================================="
+
+    $COMPARE_SCRIPT testoutput/${COMPARE_TESTNAME}.log \
+                    testref/${COMPARE_TESTNAME}.ref \
+                    ${COMPARE_TOL_F} ${COMPARE_TOL_I}
+    e=$?
+    if [[ "$e" -gt 0 ]]; then
+        echo -e "Failed in the COMPARE step. Error code: $e \n"
+        exit $e
+    fi
+    echo -e "PASSED \n"
+fi

--- a/test/testinput/hofx_nomodel.yml
+++ b/test/testinput/hofx_nomodel.yml
@@ -1,0 +1,22 @@
+window length: P1D
+window begin: 2018-04-15T00:00:00Z
+
+geometry:
+  grid: S360x180
+  domain:
+    type: global
+    west: -180
+
+forecasts:
+  date: 2018-04-15T12:00:00Z
+  state variables: [sea_surface_temperature]
+  filename: Data/19850101_regridded_sst.nc
+
+observations:
+  - obs space:
+      name: SST
+      obsdatain: {obsfile: ./Data/obs_sst.nc}
+      obsdataout: {obsfile: ./Data/hofx_sst.nc}
+      simulated variables: [sea_surface_temperature]
+    obs operator:
+      name: Identity

--- a/test/testref/hofx_nomodel.ref
+++ b/test/testref/hofx_nomodel.ref
@@ -1,0 +1,5 @@
+Test     : Initial state: min = 271.36, max = 304.956, mean = 286.307
+Test     : Final state: min = 271.36, max = 304.956, mean = 286.307
+Test     : H(x): 
+Test     : SST nobs= 174 Min=-3.33477e+38, Max=302.17, RMS=1.33477e+38
+Test     : End H(x)


### PR DESCRIPTION
This PR adds the test for the `hofx_nomodel` application, our first real working application! This application simply interpolates the background to the observation locations. Since these tests are not unit tests like we have been using so far, the way they works is:

1) The `hofx_nomodel.x` executable is run, using `testinput/hofx_nomodel.yml` input configuration, and the output log is saved to `testoutput/hofx_nomodel.log`
2) that output log is parsed for lines that start with `Test  :` and they are compared to a set of reference answers we provide at `testref/hofx_nomodel.ref`. Because answers might be slightly different on different machine, there is a tolerance allowed in the comparison script (default is `1e-12` for floats and `0` for ints, but these can be increased in `test/CMakeLists.txt` if ever needed).

`umdsst_exe_test()` helper function added to `test/CMakeLists.txt`, and `test_ wrapper.sh` file used... taken pretty much as is from the SOCA project

@loganchen39 for future reference as you're implementing the other applications, the easiest way to generate the `.ref` file is to enable the test, run it (it will fail at this point) and pull the reference lines out with `grep "Test  " testoutput/hofx_nomodel.log > testref/hofx_nomodel.ref`

closes #19 
