### PR TITLE
fix print in getvalues/lineargetvalues

### DIFF
--- a/src/umdsst/GetValues/GetValues.cc
+++ b/src/umdsst/GetValues/GetValues.cc
@@ -61,10 +61,7 @@ namespace umdsst {
 // ----------------------------------------------------------------------------
 
   void GetValues::print(std::ostream & os) const {
-    os << "insert diagnostic information about getvalues"
-      << std::endl;
-    util::abor1_cpp("GetValues::print() needs to be implemented.",
-                     __FILE__, __LINE__);
+    os << "umdsst::GetValues" << std::endl;
   }
 
 // ----------------------------------------------------------------------------

--- a/src/umdsst/GetValues/LinearGetValues.cc
+++ b/src/umdsst/GetValues/LinearGetValues.cc
@@ -108,10 +108,7 @@ namespace umdsst {
 // ----------------------------------------------------------------------------
 
   void LinearGetValues::print(std::ostream & os) const {
-    os << "insert diagnostic information about LinearGetValues"
-       << std::endl;
-    util::abor1_cpp("LinearGetValues::print() needs to be implemented.",
-                    __FILE__, __LINE__);
+    os << "umdsst::LinearGetValues" << std::endl;
   }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
ctests were failing because a recent update to `oops` tests the `print()` in `GetValues` and `LinearGetValues` interface tests.