### PR TITLE
Fixed conversion between Celsius and Kelvin.

### DIFF
--- a/src/umdsst/Fields/Fields.cc
+++ b/src/umdsst/Fields/Fields.cc
@@ -194,6 +194,7 @@ namespace umdsst {
       // mask missing values
       const double epsilon = 1.0e-6;
       const double missing_nc = -32768.0;
+      bool isKelvin = conf.getBool("kelvin", false);
       for (int j = 0; j < lat; j++)
         for (int i = 0; i < lon; i++)
           if (abs(sstData[j][i]-(missing_nc)) < epsilon) {
@@ -201,8 +202,7 @@ namespace umdsst {
           } else {
             // Kelvin to Celsius which JEDI use internally, will check if the
             // units is Kelvin or Celsius in the future
-            bool isKelvin = false;
-            if (conf.get("kelvin", isKelvin) && isKelvin)
+            if (isKelvin)
               sstData[j][i] -= 273.15;
             else
               continue;  // do nothing, for readability
@@ -285,6 +285,7 @@ namespace umdsst {
       // write data to the file
       auto fd = make_view<double, 2>(globalSst);
       float sstData[time][lat][lon];
+      bool isKelvin = conf.getBool("kelvin", false);
       int idx = 0;
       for (int j = 0; j < lat; j++)
         for (int i = 0; i < lon; i++) {
@@ -293,8 +294,7 @@ namespace umdsst {
           } else {
             // doulbe to float, also convert JEDI Celsius to Kelvin, in the
             // future it should be able to handle both Kelvin and Celsius.
-            bool isKelvin = false;
-            if (conf.get("kelvin", isKelvin) && isKelvin)
+            if (isKelvin)
               sstData[0][j][i] = static_cast<float>(fd(idx, 0)) + 273.15;
             else
               sstData[0][j][i] = static_cast<float>(fd(idx, 0));

--- a/test/testinput/hofx_nomodel.yml
+++ b/test/testinput/hofx_nomodel.yml
@@ -11,6 +11,7 @@ forecasts:
   date: 2018-04-15T12:00:00Z
   state variables: [sea_surface_temperature]
   filename: Data/19850101_regridded_sst.nc
+  kelvin: true
 
 observations:
   - obs space:

--- a/test/testinput/state.yml
+++ b/test/testinput/state.yml
@@ -11,6 +11,7 @@ state test:
   statefile:
     date: *date
     filename: Data/19850101_regridded_sst.nc
+    kelvin: true
     state variables: &state_vars [sea_surface_temperature]
   statefileout: 
     datadir: ./Data
@@ -18,4 +19,5 @@ state test:
     type: fc
     date: 1985-01-01T12:00:00Z
     filename: Data/out.19850101_regridded_sst.nc
+    kelvin: true
     state variables: *state_vars


### PR DESCRIPTION
@travissluka Passed all tests. Implemented as you suggested at #44. Be aware when using Field::read() and Field::write(), if the netCDF file temperature var is with Kelvin unit, we need to add "Kelvin: true" in the related yaml file. 

close #44.