### PR TITLE
update GetValues interface

### DIFF
--- a/src/umdsst/GetValues/GetValues.cc
+++ b/src/umdsst/GetValues/GetValues.cc
@@ -24,7 +24,8 @@ namespace umdsst {
 // ----------------------------------------------------------------------------
 
   GetValues::GetValues(const Geometry & geom,
-                       const ufo::Locations & locs)
+                       const ufo::Locations & locs,
+                       const eckit::Configuration & config)
     : geom_(new Geometry(geom)), locs_(locs) {
     interpolator_.reset( new oops::InterpolatorUnstructured(
                                eckit::LocalConfiguration(),

--- a/src/umdsst/GetValues/GetValues.h
+++ b/src/umdsst/GetValues/GetValues.h
@@ -26,6 +26,9 @@ namespace umdsst {
   class State;
 }
 
+namespace eckit {
+  class Configuration;
+}
 namespace oops {
   class InterpolatorUnstructured;
 }
@@ -46,7 +49,9 @@ namespace umdsst {
     static const std::string classname() {return "umdsst::GetValues";}
 
     // constructors, destructors
-    GetValues(const Geometry &, const ufo::Locations & locs);
+    GetValues(const Geometry &,
+              const ufo::Locations & locs,
+              const eckit::Configuration & config);
     virtual ~GetValues();
 
     // fills in geovals for all observations in the timeframe (t1, t2],


### PR DESCRIPTION
A small change to `GetValues` constructor is required due to a recent change in the oops interface. A configuration is passed in now, even though we don't use it.