### PR TITLE
add eckit::Configuration to LinearGetValues constructor

### DIFF
--- a/src/umdsst/GetValues/LinearGetValues.cc
+++ b/src/umdsst/GetValues/LinearGetValues.cc
@@ -27,7 +27,8 @@ namespace umdsst {
 // ----------------------------------------------------------------------------
 
   LinearGetValues::LinearGetValues(const Geometry & geom,
-                                   const ufo::Locations & locs)
+                                   const ufo::Locations & locs,
+                                   const eckit::Configuration & config)
     : geom_( new Geometry(geom)), locs_(locs) {
     interpolator_.reset( new oops::InterpolatorUnstructured(
                                eckit::LocalConfiguration(),

--- a/src/umdsst/GetValues/LinearGetValues.h
+++ b/src/umdsst/GetValues/LinearGetValues.h
@@ -21,6 +21,9 @@
 #include "ufo/Locations.h"
 
 // forward declarations
+namespace eckit {
+  class Configuration;
+}
 namespace oops {
   class InterpolatorUnstructured;
 }
@@ -45,7 +48,8 @@ namespace umdsst {
     static const std::string classname() {return "umdsst::LinearGetValues";}
 
     // constructors, destructors
-    LinearGetValues(const Geometry &, const ufo::Locations &);
+    LinearGetValues(const Geometry &, const ufo::Locations &,
+                    const eckit::Configuration &);
     virtual ~LinearGetValues();
 
     // Forward and backward interpolation


### PR DESCRIPTION
A small update to keep up with an interface change in JEDI.
`LinearGetValues` constructor takes a configuration as input, even though we are currently not using it.