### PR TITLE
Bugfix/grid issues

### DIFF
--- a/src/umdsst/Fields/Fields.cc
+++ b/src/umdsst/Fields/Fields.cc
@@ -210,7 +210,7 @@ namespace umdsst {
 
       // float to double
       int idx = 0;
-      for (int j = 0; j < lat; j++)
+      for (int j = lat-1; j >= 0; j--)
         for (int i = 0; i < lon; i++)
           fd(idx++, 0) = static_cast<double>(sstData[j][i]);
     }
@@ -290,7 +290,7 @@ namespace umdsst {
       float sstData[time][lat][lon];
       bool isKelvin = conf.getBool("kelvin", false);
       int idx = 0;
-      for (int j = 0; j < lat; j++)
+      for (int j = lat-1; j >= 0; j--)
         for (int i = 0; i < lon; i++) {
           if (fd(idx, 0) == missing_) {
             sstData[0][j][i] = fillvalue;

--- a/src/umdsst/Fields/Fields.cc
+++ b/src/umdsst/Fields/Fields.cc
@@ -199,13 +199,13 @@ namespace umdsst {
         for (int i = 0; i < lon; i++)
           if (abs(sstData[j][i]-(missing_nc)) < epsilon) {
             sstData[j][i] = missing_;
+            // TODO(someone) missing values that aren't a part of the landmask
+            // should be filled in instead
           } else {
             // Kelvin to Celsius which JEDI use internally, will check if the
             // units is Kelvin or Celsius in the future
             if (isKelvin)
               sstData[j][i] -= 273.15;
-            else
-              continue;  // do nothing, for readability
           }
 
       // float to double
@@ -217,6 +217,17 @@ namespace umdsst {
 
     // scatter to the PEs
     geom_->atlasFunctionSpace()->scatter(globalSst, atlasFieldSet_->field(0));
+
+    // apply mask from read in landmask
+    if ( (*geom_->atlasFieldSet()).has_field("gmask") ) {
+       atlas::Field mask_field = (*geom_->atlasFieldSet())["gmask"];
+       auto mask = make_view<int, 2>(mask_field);
+       auto fd = make_view<double, 2>(atlasFieldSet_->field(0));
+       for (int i = 0; i < mask.size(); i++) {
+         if (mask(i, 0) == 0)
+           fd(i, 0) = missing_;
+       }
+     }
   }
 
 // ----------------------------------------------------------------------------

--- a/src/umdsst/Geometry/Geometry.cc
+++ b/src/umdsst/Geometry/Geometry.cc
@@ -131,8 +131,10 @@ namespace umdsst {
       int dataLandMask[lat][lon];
       varLandMask.getVar(dataLandMask);
 
+      // TODO(someone) the netcdf lat dimension is likely inverted compared to
+      // the  atlas grid. This should be explicitly checked.
       int idx = 0;
-      for (int j = 0; j < lat; j++)
+      for (int j = lat-1; j >= 0; j--)
         for (int i = 0; i < lon; i++)
           fd(idx++, 0) = dataLandMask[j][i];
     }

--- a/src/umdsst/Geometry/Geometry.cc
+++ b/src/umdsst/Geometry/Geometry.cc
@@ -15,6 +15,7 @@
 #include "atlas/array.h"
 #include "atlas/field.h"
 #include "atlas/option.h"
+#include "atlas/util/Config.h"
 
 #include "oops/util/abor1_cpp.h"
 #include "oops/util/Logger.h"
@@ -27,7 +28,9 @@ namespace umdsst {
 
   Geometry::Geometry(const eckit::Configuration & conf,
                      const eckit::mpi::Comm & comm) : comm_(comm) {
-    atlas::RegularLonLatGrid atlasRllGrid(conf.getString("grid"));
+    atlas::util::Config gridConfig(conf.getSubConfiguration("grid"));
+    atlas::RegularLonLatGrid atlasRllGrid(gridConfig);
+
     atlasFunctionSpace_.reset(
       new atlas::functionspace::StructuredColumns(atlasRllGrid,
       atlas::option::halo(0)));

--- a/test/Data/19850101_regridded_sst.nc
+++ b/test/Data/19850101_regridded_sst.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ef2f2d5a2a164c28f63b58ad6f25d094038b821e6dd71974e723964ee0f6d9e
-size 459945
+oid sha256:a22e4a263338a99166b1e6209b183caed4b6981b40442887b2a2f886eabbc534
+size 1109711

--- a/test/testinput/dirac.yml
+++ b/test/testinput/dirac.yml
@@ -1,10 +1,11 @@
 geometry:
-  grid: S360x180
+  grid:
+    name: S360x180
+    domain:
+      type: global
+      west: -180
   landmask:
     filename: Data/landmask.nc
-  domain:
-    type: global
-    west: -180
 
 analysis variables: &vars [sea_surface_temperature]
 

--- a/test/testinput/errorcovariance.yml
+++ b/test/testinput/errorcovariance.yml
@@ -1,8 +1,9 @@
 geometry:
-  grid: S360x180
-  domain:
-    type: global
-    west: -180
+  grid:
+    name: S360x180
+    domain:
+      type: global
+      west: -180
   landmask:
     filename: Data/landmask.nc
 

--- a/test/testinput/geometry.yml
+++ b/test/testinput/geometry.yml
@@ -1,8 +1,9 @@
 geometry:
-  grid: S360x180
-  domain:
-    type: global
-    west: -180
+  grid:
+    name: S360x180
+    domain:
+      type: global
+      west: -180
 
   landmask:
     filename: Data/landmask.nc

--- a/test/testinput/getvalues.yml
+++ b/test/testinput/getvalues.yml
@@ -1,8 +1,11 @@
 geometry:
-  grid: S360x180
-  domain:
-    type: global
-    west: -180
+  grid:
+    name: S360x180
+    domain:
+      type: global
+      west: -180
+  landmask:
+    filename: Data/landmask.nc
 
 state variables: &state_vars [sea_surface_temperature]
 

--- a/test/testinput/hofx3d.yml
+++ b/test/testinput/hofx3d.yml
@@ -2,10 +2,13 @@ window length: P1D
 window begin: 2018-04-15T00:00:00Z
 
 geometry:
-  grid: S360x180
-  domain:
-    type: global
-    west: -180
+  grid:
+    name: S360x180
+    domain:
+      type: global
+      west: -180
+  landmask:
+    filename: Data/landmask.nc
 
 state:
   date: 2018-04-15T12:00:00Z

--- a/test/testinput/increment.yml
+++ b/test/testinput/increment.yml
@@ -1,8 +1,11 @@
 geometry:
-  grid: S360x180
-  domain:
-    type: global
-    west: -180
+  grid:
+    name: S360x180
+    domain:
+      type: global
+      west: -180
+  landmask:
+    filename: Data/landmask.nc
 
 inc variables: [sea_surface_temperature]
 

--- a/test/testinput/lineargetvalues.yml
+++ b/test/testinput/lineargetvalues.yml
@@ -1,8 +1,11 @@
 geometry:
-  grid: S360x180
-  domain:
-    type: global
-    west: -180
+  grid:
+    name: S360x180
+    domain:
+      type: global
+      west: -180
+  landmask:
+    filename: Data/landmask.nc
 
 state variables: &state_vars [sea_surface_temperature]
 

--- a/test/testinput/linearvarchange_stddev.yml
+++ b/test/testinput/linearvarchange_stddev.yml
@@ -1,8 +1,9 @@
 geometry:
-  grid: S360x180
-  domain:
-    type: global
-    west: -180
+  grid:
+    name: S360x180
+    domain:
+      type: global
+      west: -180
   landmask:
     filename: Data/landmask.nc
 

--- a/test/testinput/state.yml
+++ b/test/testinput/state.yml
@@ -1,11 +1,15 @@
 geometry:
-  grid: S360x180
-  domain:
-    type: global
-    west: -180
+  grid:
+    name: S360x180
+    domain:
+      type: global
+      west: -180
+  landmask:
+    filename: Data/landmask.nc
+
 
 state test:
-  norm file: 17.409813550061454  # 286.53398478426465
+  norm file: 17.618557808088323
   tolerance: 1e-6
   date: &date 1985-01-01T12:00:00Z
   statefile:
@@ -13,7 +17,7 @@ state test:
     filename: Data/19850101_regridded_sst.nc
     kelvin: true
     state variables: &state_vars [sea_surface_temperature]
-  statefileout: 
+  statefileout:
     datadir: ./Data
     exp: out
     type: fc

--- a/test/testinput/staticbinit.yml
+++ b/test/testinput/staticbinit.yml
@@ -1,10 +1,11 @@
 geometry:
-  grid: S360x180
+  grid:
+    name: S360x180
+    domain:
+      type: global
+      west: -180
   landmask:
     filename: Data/landmask.nc
-  domain:
-    type: global
-    west: -180
 
 analysis variables: &vars [sea_surface_temperature]  # must have
 

--- a/test/testinput/var.yml
+++ b/test/testinput/var.yml
@@ -4,13 +4,14 @@ cost function:
   window length: PT24H
   analysis variables: &vars [sea_surface_temperature]
 
-  geometry:
-    grid: S360x180
+  geometry: &geometry
+    grid:
+      name: S360x180
+      domain:
+        type: global
+        west: -180
     landmask:
       filename: Data/landmask.nc
-    domain:
-      type: global
-      west: -180
 
   background:
     state variables: *vars
@@ -64,13 +65,7 @@ variational:
       departures: ombg
     gradient norm reduction: 1.0e-10
     ninner: 10
-    geometry:
-      grid: S360x180
-      landmask:
-        filename: Data/landmask.nc
-      domain:
-        type: global
-        west: -180
+    geometry: *geometry
     test: on
     online diagnostics:
       write increment: true

--- a/test/testref/dirac.ref
+++ b/test/testref/dirac.ref
@@ -1,2 +1,2 @@
 Test     : Input Dirac increment: min = 0, max = 1, mean = 0.000138889
-Test     : B * Increment: min = -0, max = 1, mean = 0.0697115
+Test     : B * Increment: min = -0, max = 1, mean = 0.0594276

--- a/test/testref/hofx3d.ref
+++ b/test/testref/hofx3d.ref
@@ -1,4 +1,4 @@
-Test     : State: min = -1.79, max = 31.8058, mean = 13.1571
-Test     : H(x):
-Test     : SST nobs= 174 Min=-3.33477e+38, Max=29.0197, RMS=1.33477e+38
+Test     : State: min = -1.74296, max = 30.7226, mean = 13.5655
+Test     : H(x): 
+Test     : SST nobs= 200 Min=-2.5419e+38, Max=29.7967, RMS=3.39967e+37
 Test     : End H(x)

--- a/test/testref/var.ref
+++ b/test/testref/var.ref
@@ -1,9 +1,9 @@
 Test     : CostJb   : Nonlinear Jb = 0
-Test     : CostJo   : Nonlinear Jo(sea_surface_temperature) = 8450.12, nobs = 127, Jo/n = 66.5364, err = 0.369977
-Test     : CostFunction: Nonlinear J = 8450.12
-Test     : DRIPCGMinimizer: reduction in residual norm = 0.0429602
-Test     : CostFunction::addIncrement: Analysis: min = -5.77236, max = 31.8058, mean = 13.4612
+Test     : CostJo   : Nonlinear Jo(sea_surface_temperature) = 2106.96, nobs = 188, Jo/n = 11.2072, err = 0.363015
+Test     : CostFunction: Nonlinear J = 2106.96
+Test     : DRIPCGMinimizer: reduction in residual norm = 0.0523644
+Test     : CostFunction::addIncrement: Analysis: min = -2.21605, max = 32.2463, mean = 13.9286
 Test     : umdsst::ModelAuxControl not implemented
-Test     : CostJb   : Nonlinear Jb = 489.763
-Test     : CostJo   : Nonlinear Jo(sea_surface_temperature) = 191.27, nobs = 127, Jo/n = 1.50606, err = 0.369977
-Test     : CostFunction: Nonlinear J = 681.033
+Test     : CostJb   : Nonlinear Jb = 99.0877
+Test     : CostJo   : Nonlinear Jo(sea_surface_temperature) = 59.1677, nobs = 188, Jo/n = 0.314722, err = 0.363015
+Test     : CostFunction: Nonlinear J = 158.255


### PR DESCRIPTION
several bug related to the grid are fixed here. They were causing problems when trying to do real cycling.

- The `y` dimension was inverted compared to what is in the netcdf files. The netcdf files start with latitude of 89.5 S, but the atlas grid starts with a latitude of 89.5 N. The y dimension is now explicitly flipped when reading/writing netcdf files (in the long term, however, the actual lat/lon of input files should be checked and remapped to the target grid... we'll worry about that later once new interpolation is added to JEDI)
- there was a discrepancy in the masking of the background file and the landmask file. The background file missing values are  now filled in with `cdo fillmiss` and now has the landmask directly applied to it in `Fields::read()`
- The longitude was off by 180 degrees because atlas was not being passed the full yaml configuration.

yaml and reference answers have been updated to reflect the changes in answers 