### PR TITLE
add cycling script

### DIFF
--- a/cycling/config/staticbinit.yaml
+++ b/cycling/config/staticbinit.yaml
@@ -1,0 +1,34 @@
+geometry:
+  grid:
+    name: S360x180
+    domain:
+      type: global
+      west: -180
+  landmask:
+    filename: landmask.nc
+
+analysis variables: &vars [sea_surface_temperature]
+
+background:
+  state variables: *vars
+  date: 2018-04-15T00:00:00Z # date doesn't matter here, just pick something
+  filename: bkg.nc
+
+background error:
+  covariance model: umdsstCovar
+  bump:
+    verbosity: main
+    datadir: bump
+    prefix: bump_sst
+    method: cor
+    strategy: specific_univariate
+    mask_check: 1
+    network: 1
+    new_nicas: 1
+    ntry: 3
+    resol: 6.0
+    mpicom: 2
+    nc1max: 40000
+
+  correlation lengths:
+    fixed: 200.0e3

--- a/cycling/config/var.yaml
+++ b/cycling/config/var.yaml
@@ -1,0 +1,92 @@
+cost function:
+  cost type: 3D-Var
+  window begin: __DA_WINDOW_START__
+  window length: PT24H
+  analysis variables: &vars [sea_surface_temperature]
+
+  geometry: &geometry
+    grid:
+      name: S360x180
+      domain:
+        type: global
+        west: -180
+    landmask:
+      filename: landmask.nc
+
+  background:
+    state variables: *vars
+    date: __ANA_DATE__
+    filename: bkg.nc
+    kelvin: true
+
+  background error:
+    covariance model: BUMP
+    bump:
+      verbosity: main
+      datadir: bump
+      prefix: bump_sst
+      method: cor
+      strategy: specific_univariate
+      mask_check: 1
+      network: 1
+      load_nicas: 1
+      mpicom: 2
+
+    variable changes:
+    - variable change: umdsstStdDev
+      input variables: *vars
+      output variables: *vars
+      fixed: 1.0
+
+  observations:
+  - obs error:
+      covariance model: diagonal
+    obs operator:
+      name: Identity
+    obs space:
+      name: sea_surface_temperature
+      obsdatain:
+        obsfile: obs_ioda.nc
+      simulated variables: [sea_surface_temperature]
+      obsdataout:
+        obsfile: obs_out/obs.nc
+    obs filters:
+    - filter: PreQC  # only keep obs with the best 2 qc levels from original data file
+      maxvalue: 1
+    - filter: BlackList  # assign initial error value
+      action:
+        name: assign error
+        error parameter: 1.0
+    - filter: Domain Check  # land check
+      where:
+      - variable: {name: sea_area_fraction@GeoVaLs}
+        minvalue: 1.0
+    - filter: Background Check
+      absolute threshold: 5.0
+    - filter: Bounds Check
+      minvalue: 0.0 # ignore obs that are close to freezing, for now
+      maxvalue: 40.0
+
+variational:
+  minimizer:
+    algorithm: DRIPCG
+
+  iterations:
+  - diagnostics:
+      departures: ombg
+    gradient norm reduction: 1.0e-3
+    ninner: 200
+    geometry: *geometry
+    test: on
+    online diagnostics:
+      write increment: true
+    increment:
+      filename: inc.nc
+
+final:
+  diagnostics:
+    departures: oman
+
+output:
+  filename: ana.nc
+  kelvin: true

--- a/cycling/cycle.sh
+++ b/cycling/cycle.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+set -eu
+
+#-------------------------------------------------------------------------------
+# user configurables that should be set before running
+#-------------------------------------------------------------------------------
+
+EXP_DIR=$(readlink -f .) # assume experiment directory is the directory
+                         # that this script is in
+
+EXP_START_DATE=20160101Z12  # start date, in YYYYMMDDZHH format
+EXP_END_DATE=20160131Z12    # end date,   in YYYYMMDDZHH format
+
+# location of root UMD-SST source directory
+# (not needed by this script, other than the subsequent default IC/landmask locations)
+UMDSST_SRC_DIR=/home/tsluka/work/umdsst/umd-sst.src
+
+# location of the UMD-SST binary files
+UMDSST_BIN_DIR=/home/tsluka/work/umdsst/umd-sst.release/bin
+
+# observation locations, note that %Y %m %d %H will be replaced with the
+# date/time of each cycle
+OBS_FILE=$EXP_DIR/obs/%Y%m%d%H0000-ESACCI-L3C_GHRSST-SSTskin-AVHRR19_G-CDR2.1_night-v02.0-fv01.0.nc
+
+OBS_THINNING=0.8 # percent of obs to discard (range: 0.0 - 1.0 )
+
+# initial background used for the first cycle
+IC_FILE=$UMDSST_SRC_DIR/test/Data/19850101_regridded_sst.nc
+
+# land mask file
+LANDMASK_FILE=$UMDSST_SRC_DIR/test/Data/landmask.nc
+
+# temporary working files, that are deleted after each cycle is finished
+SCRATCH_DIR=$EXP_DIR/SCRATCH
+
+#-------------------------------------------------------------------------------
+# END of user configurables
+#-------------------------------------------------------------------------------
+
+
+# you probably dont need to edit anything below here...
+
+# define some other variables used by this script
+export OMP_NUM_THREADS=1  # OpenMP isn't working correctly, disable
+DA_WINDOW_LEN=24          # assuming a fixed window of 1 day, for now
+
+#================================================================================
+#================================================================================
+# Start of loop
+#================================================================================
+#================================================================================
+export TIMEFORMAT='%1Rs'
+date_fmt="%Y-%m-%dT%H:%M:%SZ"
+cycle_avg_count=0
+cycle_avg_runtime=0
+while true; do
+    cycle_start=$(date +%s)
+
+    # determine where the experiment left off and if this is the first cycle
+    cycle_status_file=$EXP_DIR/cycle_status
+    if [[ ! -e $cycle_status_file ]]; then
+        cycle_start_date=$(date -ud "$EXP_START_DATE" +$date_fmt)
+        init=1
+    else
+        cycle_start_date=$(cat $cycle_status_file)
+        init=0
+    fi
+
+    # are we done with the experiment?
+    if [[ $(date -ud "$cycle_start_date" +%Y%m%d%H) -gt \
+          $(date -ud "$EXP_END_DATE" +%Y%m%d%H) ]]; then
+        echo "Done with the experiment. Last date: $cycle_start_date"
+        exit 0
+    fi
+
+    # variables that depend on the cycle date
+    ANA_DATE=$(date -ud "$cycle_start_date" +$date_fmt)
+    DA_WINDOW_HW=$(( DA_WINDOW_LEN/2 ))
+    DA_WINDOW_START=$(date -ud "$ANA_DATE - $DA_WINDOW_HW hours" +$date_fmt)
+    NEXT_DATE=$(date -ud "$ANA_DATE + $DA_WINDOW_LEN hours" +$date_fmt)
+    PREV_DATE_YMDH=$(date -ud "$ANA_DATE - $DA_WINDOW_LEN hours" +"%Y%m%d%H")
+    ANA_DATE_YMDH=$(date -ud "$ANA_DATE" +"%Y%m%d%H")
+    SCRATCH_DIR_CYCLE=$SCRATCH_DIR/$ANA_DATE_YMDH
+
+    echo ""
+    echo "======================================================================"
+    echo "analysis date: $ANA_DATE"
+    echo "======================================================================"
+
+    # setup working directory
+    [[ -d "$SCRATCH_DIR_CYCLE" ]]  && rm -r $SCRATCH_DIR_CYCLE
+    mkdir -p $SCRATCH_DIR_CYCLE
+    cd $SCRATCH_DIR_CYCLE
+    ln -s $LANDMASK_FILE landmask.nc
+
+    # link in the most recent background state
+    if [[ "$init" == 1 ]]; then
+        ln -s $IC_FILE bkg.nc
+    else
+        ln -s $EXP_DIR/ana/ana.$PREV_DATE_YMDH.nc bkg.nc
+    fi
+
+    # initialize bump if not already done so
+    BUMP_DIR=$EXP_DIR/bump
+    if [[ ! -d "$BUMP_DIR" ]]; then
+        echo "Initializing BUMP..."
+        mkdir bump
+        cp $EXP_DIR/config/staticbinit.yaml .
+        mpirun $UMDSST_BIN_DIR/umdsst_staticbinit.x staticbinit.yaml
+        mv bump $BUMP_DIR
+    fi
+    ln -s $BUMP_DIR bump
+
+    # run ioda converter
+    obs_file=$(date -ud "$ANA_DATE" +$OBS_FILE)
+    $UMDSST_BIN_DIR/gds2_sst2ioda.py -i $obs_file -o obs_ioda.nc \
+        -d $ANA_DATE_YMDH --sst -t $OBS_THINNING
+
+    # run the var
+    mkdir -p obs_out
+    cp $EXP_DIR/config/var.yaml .
+    sed -i "s/__DA_WINDOW_START__/${DA_WINDOW_START}/g" var.yaml
+    sed -i "s/__ANA_DATE__/${ANA_DATE}/g" var.yaml
+    mpirun $UMDSST_BIN_DIR/umdsst_var.x var.yaml
+
+    # move the output files
+    ana_file=$EXP_DIR/ana/ana.${ANA_DATE_YMDH}.nc
+    mkdir -p $(dirname $ana_file)
+    mv ana.nc $ana_file
+
+    inc_file=$EXP_DIR/inc/inc.${ANA_DATE_YMDH}.nc
+    mkdir -p $(dirname $inc_file)
+    mv inc.nc $inc_file
+
+    # moving observation output stats as is
+    # TODO: concatenate into a single file per platform
+    obs_out_dir=$EXP_DIR/obs_out/${ANA_DATE_YMDH}
+    mkdir -p $obs_out_dir
+    mv obs_out/*.nc $obs_out_dir
+
+    # done with this day of the cycle, cleanup and prepare for the next cycle
+    rm -rf $SCRATCH_DIR_CYCLE
+    echo "$NEXT_DATE" > $cycle_status_file
+
+    # update statistics on average cycle runtime
+    cycle_end=$(date +%s)
+    cycle_runtime=$((cycle_end-cycle_start ))
+    cycle_avg_runtime=$(((cycle_avg_runtime*cycle_avg_count+cycle_runtime)/(cycle_avg_count+1) ))
+    cycle_avg_count=$((cycle_avg_count+1))
+    echo "Cycle runtime:     $cycle_runtime seconds"
+    echo "Cycle runtime avg: $cycle_avg_runtime seconds"
+done


### PR DESCRIPTION
A basic cycling script is added in the `cycling/` directory.

This script will use the initial background and landmask files that are already present in `test/Data/`. The analysis of each cycle will then be used as the background of the next cycle. A separate set of var and staticbinit yaml files are added, intended to be more realistic than what is used for the ctests.

To use:
 - build umdsst, including `ioda-converters`
 - copy the `cycling/` directory to a new directory for the experiment
 - modify the variables at the top of `<new_exp_dir>/cycling.sh` to set the appropriate date and input file locations.
 - run `./cycling.sh`

There should `ana/`, `inc/` and `obs_out/` directories that are populated as the script runs.
If the script is aborted, it will resume where it left off when rerun.

@loganchen39  The ctests do not test this script so be sure to test it yourself.