### PR TITLE
Rossby radius based horizontal correlation lengths

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.nc    filter=lfs diff=lfs merge=lfs -text
 *.nc4   filter=lfs diff=lfs merge=lfs -text
+*.dat filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+*.dat   filter=lfs diff=lfs merge=lfs -text
 *.nc    filter=lfs diff=lfs merge=lfs -text
 *.nc4   filter=lfs diff=lfs merge=lfs -text
 *.dat filter=lfs diff=lfs merge=lfs -text

--- a/cycling/config/staticbinit.yaml
+++ b/cycling/config/staticbinit.yaml
@@ -28,7 +28,12 @@ background error:
     ntry: 3
     resol: 6.0
     mpicom: 2
-    nc1max: 40000
+    nc1max: 100000
 
   correlation lengths:
-    fixed: 200.0e3
+    base value: 0.0
+    rossby mult: 1.0
+    min grid mult: 1.5
+    #min value: 25.0e3
+    #max value:
+

--- a/cycling/config/staticbinit.yaml
+++ b/cycling/config/staticbinit.yaml
@@ -6,6 +6,7 @@ geometry:
       west: -180
   landmask:
     filename: landmask.nc
+  rossby radius file: rossby_radius.dat
 
 analysis variables: &vars [sea_surface_temperature]
 

--- a/cycling/cycle.sh
+++ b/cycling/cycle.sh
@@ -30,6 +30,8 @@ IC_FILE=$UMDSST_SRC_DIR/test/Data/19850101_regridded_sst.nc
 # land mask file
 LANDMASK_FILE=$UMDSST_SRC_DIR/test/Data/landmask.nc
 
+ROSSBYRADIUS_FILE=$UMDSST_SRC_DIR/test/Data/rossby_radius.dat
+
 # temporary working files, that are deleted after each cycle is finished
 SCRATCH_DIR=$EXP_DIR/SCRATCH
 
@@ -92,6 +94,7 @@ while true; do
     mkdir -p $SCRATCH_DIR_CYCLE
     cd $SCRATCH_DIR_CYCLE
     ln -s $LANDMASK_FILE landmask.nc
+    ln -s $ROSSBYRADIUS_FILE rossby_radius.dat
 
     # link in the most recent background state
     if [[ "$init" == 1 ]]; then

--- a/src/umdsst/Covariance/Covariance.cc
+++ b/src/umdsst/Covariance/Covariance.cc
@@ -5,6 +5,8 @@
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+#include <algorithm>
+#include <limits>
 #include <ostream>
 #include <string>
 
@@ -85,23 +87,24 @@ namespace umdsst {
       double maxValue = corrConf.getDouble("max value",
                                        std::numeric_limits<double>::max());
 
-      atlas::Field f_rossbyRadius = geom.atlasFieldSet()->field("rossby_radius");
-      auto rossbyRadius = atlas::array::make_view<double, 2>(f_rossbyRadius);
+      auto rossbyRadius = atlas::array::make_view<double, 2>(
+        geom.atlasFieldSet()->field("rossby_radius");
       auto area = atlas::array::make_view<double, 2>(
          geom.atlasFieldSet()->field("area"));
 
       param_view.assign(baseValue);
-      for (int i = 0; i < param_field.size(); i++ ) {
-        param_view(i,0) += rossbyMult * rossbyRadius(i,0);
-        param_view(i,0) = std::max(param_view(i,0), minGridMult*sqrt(area(i,0)));
-        param_view(i,0) = std::max(param_view(i,0), minValue);
-        param_view(i,0) = std::min(param_view(i,0), maxValue);
+      for ( int i = 0; i < param_field.size(); i++ ) {
+        param_view(i, 0) += rossbyMult * rossbyRadius(i, 0);
+        param_view(i, 0) = std::max(param_view(i, 0),
+                                    minGridMult*sqrt(area(i, 0)));
+        param_view(i, 0) = std::max(param_view(i, 0), minValue);
+        param_view(i, 0) = std::min(param_view(i, 0), maxValue);
       }
 
       // note: BUMP expects the length as a Gaspari-Cohn cutoff length,
       //   but we probably think of it as a Gaussian 1 sigma, so convert.
-      for (int i = 0; i < param_field.size(); i++ ) {
-        param_view(i,0) *= 3.57; // gaussian to GC factor
+      for ( int i = 0; i < param_field.size(); i++ ) {
+        param_view(i, 0) *= 3.57;  // gaussian to GC factor
       }
 
       param_name = "cor_rh";

--- a/src/umdsst/Covariance/Covariance.cc
+++ b/src/umdsst/Covariance/Covariance.cc
@@ -85,8 +85,8 @@ namespace umdsst {
       double maxValue = corrConf.getDouble("max value",
                                        std::numeric_limits<double>::max());
 
-      auto rossbyRadius = atlas::array::make_view<double, 2>(
-         geom.atlasFieldSet()->field("rossby_radius"));
+      atlas::Field f_rossbyRadius = geom.atlasFieldSet()->field("rossby_radius");
+      auto rossbyRadius = atlas::array::make_view<double, 2>(f_rossbyRadius);
       auto area = atlas::array::make_view<double, 2>(
          geom.atlasFieldSet()->field("area"));
 

--- a/src/umdsst/Covariance/Covariance.cc
+++ b/src/umdsst/Covariance/Covariance.cc
@@ -88,7 +88,7 @@ namespace umdsst {
                                        std::numeric_limits<double>::max());
 
       auto rossbyRadius = atlas::array::make_view<double, 2>(
-        geom.atlasFieldSet()->field("rossby_radius");
+        geom.atlasFieldSet()->field("rossby_radius"));
       auto area = atlas::array::make_view<double, 2>(
          geom.atlasFieldSet()->field("area"));
 

--- a/src/umdsst/Geometry/Geometry.cc
+++ b/src/umdsst/Geometry/Geometry.cc
@@ -197,6 +197,9 @@ namespace umdsst {
     const std::vector<eckit::geometry::Point2> & srcLonLat,
     const std::vector<double> & srcVal) const
   {
+    // Interpolate the values from the given lat/lons onto the grid that is
+    // represented by this geometry. Note that this assumes each PE is
+    // presenting an identical copy of srcLonLat and srcVal.
     struct TreeTrait {
       typedef eckit::geometry::Point3 Point;
       typedef double                  Payload;

--- a/src/umdsst/Geometry/Geometry.cc
+++ b/src/umdsst/Geometry/Geometry.cc
@@ -6,15 +6,18 @@
  */
 
 #include "netcdf"
+#include <fstream>
 
 #include "umdsst/Geometry/Geometry.h"
 
+#include "eckit/container/KDTree.h"
 #include "eckit/config/Configuration.h"
 
 #include "atlas/grid.h"
 #include "atlas/array.h"
 #include "atlas/field.h"
 #include "atlas/option.h"
+#include "atlas/functionspace.h"
 #include "atlas/util/Config.h"
 
 #include "oops/util/abor1_cpp.h"
@@ -60,6 +63,9 @@ namespace umdsst {
       area_data(i, 0) = dx*dx*cos(lonlat_data(i, 1)*M_PI/180.);
     }
     atlasFieldSet_->add(area);
+
+    // add field for rossby radius
+    readRossbyRadius();
   }
 
 // ----------------------------------------------------------------------------
@@ -166,4 +172,71 @@ namespace umdsst {
 
 // ----------------------------------------------------------------------------
 
+  void Geometry::readRossbyRadius() {
+    std::ifstream infile("Data/rossby_radius.dat");
+    std::vector<eckit::geometry::Point2> lonlat;
+    std::vector<double> vals;
+    double lat, lon, x, val;
+
+    while (infile >> lat >> lon >> x >> val) {
+      lonlat.push_back(eckit::geometry::Point2(lon, lat));
+      vals.push_back(val);
+    }
+
+    atlas::Field field = interpToGeom(lonlat, vals);
+    field.rename("rossby_radius");
+    atlasFieldSet_->add(field);
+  }
+
+// ----------------------------------------------------------------------------
+
+  atlas::Field Geometry::interpToGeom(
+    const std::vector<eckit::geometry::Point2> & srcLonLat,
+    const std::vector<double> & srcVal) const
+  {
+    struct TreeTrait {
+      typedef eckit::geometry::Point3 Point;
+      typedef double                  Payload;
+    };
+    typedef eckit::KDTreeMemory<TreeTrait> KDTree;
+    const int maxSearchPoints = 4;
+
+    // Create a KD tree for fast lookup
+    std::vector<typename KDTree::Value> srcPoints;
+    for (int i = 0; i < srcVal.size(); i++) {
+      KDTree::PointType xyz;
+      atlas::util::Earth::convertSphericalToCartesian(srcLonLat[i], xyz);
+      srcPoints.push_back(KDTree::Value(xyz, srcVal[i]) );
+    }
+    KDTree kd;
+    kd.build(srcPoints.begin(), srcPoints.end());
+
+    // Interpolate (inverse distance weighted)
+    atlas::Field dstField = atlasFunctionSpace_->createField<double>(
+      atlas::option::levels(1));
+    auto dstView = make_view<double, 2>(dstField);
+    auto dstLonLat = make_view<double, 2>(atlasFunctionSpace_->lonlat());
+    for (int i=0; i < atlasFunctionSpace_->size(); i++) {
+      eckit::geometry::Point2 dstPoint({dstLonLat(i,0),dstLonLat(i,1)});
+      eckit::geometry::Point3 dstPoint3D;
+      atlas::util::Earth::convertSphericalToCartesian(dstPoint, dstPoint3D);
+      auto points = kd.kNearestNeighbours(dstPoint3D, maxSearchPoints);
+      double sumDist = 0.0;
+      double sumDistVal = 0.0;
+      for (int n =0; n < points.size(); n++ ) {
+        if (points[n].distance() < 1.0e-6 ) {
+          sumDist = 1.0;
+          sumDistVal = points[n].payload();
+          break;
+        }
+        double w = 1.0 / (points[n].distance()*points[n].distance());
+        sumDist += w;
+        sumDistVal += w*points[n].payload();
+      }
+
+      dstView(i,0) = sumDistVal / sumDist;
+    }
+
+    return dstField;
+  }
 }  // namespace umdsst

--- a/src/umdsst/Geometry/Geometry.cc
+++ b/src/umdsst/Geometry/Geometry.cc
@@ -173,14 +173,16 @@ namespace umdsst {
 // ----------------------------------------------------------------------------
 
   void Geometry::readRossbyRadius() {
-    std::ifstream infile("Data/rossby_radius.dat");
+    //TODO pass in filename
+    //std::ifstream infile("Data/rossby_radius.dat");
+    std::ifstream infile("rossby_radius.dat");
     std::vector<eckit::geometry::Point2> lonlat;
     std::vector<double> vals;
     double lat, lon, x, val;
 
     while (infile >> lat >> lon >> x >> val) {
       lonlat.push_back(eckit::geometry::Point2(lon, lat));
-      vals.push_back(val);
+      vals.push_back(val*1.0e3);
     }
 
     atlas::Field field = interpToGeom(lonlat, vals);

--- a/src/umdsst/Geometry/Geometry.h
+++ b/src/umdsst/Geometry/Geometry.h
@@ -8,10 +8,10 @@
 #ifndef UMDSST_GEOMETRY_GEOMETRY_H_
 #define UMDSST_GEOMETRY_GEOMETRY_H_
 
+#include <memory>
 #include <ostream>
 #include <string>
-
-#include <memory>
+#include <vector>
 
 #include "atlas/functionspace.h"
 #include "atlas/field.h"
@@ -64,7 +64,7 @@ namespace umdsst {
    private:
     atlas::Field interpToGeom(const std::vector<eckit::geometry::Point2> &,
                               const std::vector<double> &) const;
-    void readRossbyRadius();
+    void readRossbyRadius(const std::string &);
     void print(std::ostream &) const;
     const eckit::mpi::Comm & comm_;
 

--- a/src/umdsst/Geometry/Geometry.h
+++ b/src/umdsst/Geometry/Geometry.h
@@ -62,6 +62,9 @@ namespace umdsst {
     }
 
    private:
+    atlas::Field interpToGeom(const std::vector<eckit::geometry::Point2> &,
+                              const std::vector<double> &) const;
+    void readRossbyRadius();
     void print(std::ostream &) const;
     const eckit::mpi::Comm & comm_;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,8 +22,9 @@ list( APPEND umdsst_test_ref
 
 list( APPEND umdsst_test_data
   Data/19850101_regridded_sst.nc
-  Data/obs_sst.nc
   Data/landmask.nc
+  Data/obs_sst.nc
+  Data/rossby_radius.dat
   )
 
 

--- a/test/Data/rossby_radius.dat
+++ b/test/Data/rossby_radius.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2a49cdc619ec8c44186bc6a8de7bf607734868c923236e0805644c0bf5c54dd
+size 1117445

--- a/test/testinput/staticbinit.yml
+++ b/test/testinput/staticbinit.yml
@@ -6,6 +6,7 @@ geometry:
       west: -180
   landmask:
     filename: Data/landmask.nc
+  rossby radius file: Data/rossby_radius.dat
 
 analysis variables: &vars [sea_surface_temperature]  # must have
 

--- a/test/testinput/staticbinit.yml
+++ b/test/testinput/staticbinit.yml
@@ -29,4 +29,6 @@ background error:
     mpicom: 2
     strategy: specific_univariate
   correlation lengths:
-    fixed: 840.0e3
+    base value: 840.0e3
+    # rossby mult: 1.0
+    # min grid mult: 1.0

--- a/test/testinput/staticbinit.yml
+++ b/test/testinput/staticbinit.yml
@@ -28,7 +28,9 @@ background error:
     resol: 6.0
     mpicom: 2
     strategy: specific_univariate
+    nc1max: 100000
   correlation lengths:
-    base value: 840.0e3
-    # rossby mult: 1.0
-    # min grid mult: 1.0
+    base value: 500.0e3
+    rossby mult: 1.0
+    min grid mult: 5.0
+    #min value: 200.0e3

--- a/test/testref/dirac.ref
+++ b/test/testref/dirac.ref
@@ -1,2 +1,2 @@
 Test     : Input Dirac increment: min = 0, max = 1, mean = 0.000138889
-Test     : B * Increment: min = -0, max = 1, mean = 0.0594276
+Test     : B * Increment: min = -0, max = 1, mean = 0.0237249

--- a/test/testref/var.ref
+++ b/test/testref/var.ref
@@ -1,9 +1,9 @@
 Test     : CostJb   : Nonlinear Jb = 0
 Test     : CostJo   : Nonlinear Jo(sea_surface_temperature) = 2106.96, nobs = 188, Jo/n = 11.2072, err = 0.363015
 Test     : CostFunction: Nonlinear J = 2106.96
-Test     : DRIPCGMinimizer: reduction in residual norm = 0.0523644
-Test     : CostFunction::addIncrement: Analysis: min = -2.21605, max = 32.2463, mean = 13.9286
+Test     : DRIPCGMinimizer: reduction in residual norm = 0.0278441
+Test     : CostFunction::addIncrement: Analysis: min = -2.16241, max = 32.1528, mean = 13.8328
 Test     : umdsst::ModelAuxControl not implemented
-Test     : CostJb   : Nonlinear Jb = 99.0877
-Test     : CostJo   : Nonlinear Jo(sea_surface_temperature) = 59.1677, nobs = 188, Jo/n = 0.314722, err = 0.363015
-Test     : CostFunction: Nonlinear J = 158.255
+Test     : CostJb   : Nonlinear Jb = 111.292
+Test     : CostJo   : Nonlinear Jo(sea_surface_temperature) = 28.1357, nobs = 188, Jo/n = 0.149658, err = 0.363015
+Test     : CostFunction: Nonlinear J = 139.427


### PR DESCRIPTION
This PR adds the ability to use the local Rossby radius in the calculation of the horizontal correlation lengths. The following options are now added to the yaml, with their default values shown.

```yaml
correlation lengths:
  base value: 0.0
  rossby mult: 0.0
  min grid mult: 0.0
  min value: 0.0
  max value: 1.79769e+308
```

correlation lengths are equal to `base_value + rossby_mult * rossby_radius`, and are then clamped to be no smaller than `min_value` and `min_grid_mult * grid_box_size`, and no larger than `max_value`.

- a text file `rossby_radius.dat` is added with the Rossby radius data
- that file is read in by `Geometry` and interpolated to the grid 
- because the existing interpolation wasn't working (the `oops` interpolation assumes each PE has separate sections of lat/lon that need to be combined, and the `atlas` interpolation doesn't work on > 1 PE) I implemented a kd-tree based n-nearest neighbor inverse distance weighted interpolation `interpToGeom()`. We could, in the future, use this interpolation for other files we need to load in, including reading in a background that is not on the grid.

@loganchen39 For your cycling experiments, I would start off with the values I have placed in the `cycling/config/staticbinit.yaml` file, which will use the Rossby radius as the correlation length, with a minimum value in the extratropics that are slightly larger than an individual gridbox.