### PR TITLE
support for modules with new ecbuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
 - |
   # build code
   docker exec -it jcsda_container bash \
-   -c 'cd /jcsda/build && ecbuild /jcsda/src/bundle && cd umdsst && make -j 4; exit $?' \
+   -c 'cd /jcsda/build && ecbuild -DBUILD_FCKIT=ON -DBUILD_ATLAS=ON /jcsda/src/bundle && cd umdsst && make -j 4; exit $?' \
    || travis_terminate 1
 
 - |
@@ -40,5 +40,5 @@ script:
   docker exec -it jcsda_container bash \
    -c 'cd /jcsda/build/umdsst && ctest --output-on-failure' \
    || travis_terminate 1
-  
-after_success: 
+
+after_success:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,113 +6,37 @@
 ################################################################################
 # UMDSST
 ################################################################################
+cmake_minimum_required( VERSION 3.12 )
+project( umdsst VERSION 2021.5.0 LANGUAGES C CXX Fortran)
 
-cmake_minimum_required( VERSION 3.8 FATAL_ERROR )
-
-project( umdsst C CXX Fortran)
-
-set( CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH})
-
-set( ENABLE_OS_TESTS           OFF CACHE BOOL "Disable OS tests" FORCE )
-set( ENABLE_LARGE_FILE_SUPPORT OFF CACHE BOOL "Disable testing of large file support" FORCE )
-set( ENABLE_MPI                ON CACHE BOOL "Compile with MPI" )
-
+find_package(ecbuild 3.3.2 QUIET)
 include( ecbuild_system NO_POLICY_SCOPE )
-
-ecbuild_requires_macro_version( 2.5 )
-
-
-################################################################################
-# Project
-################################################################################
-
 ecbuild_declare_project()
 
-ecbuild_enable_fortran( REQUIRED )
-ecbuild_add_cxx11_flags()
-
-set( UMDSST_LINKER_LANGUAGE CXX )
+list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+include( umdsst_compiler_flags )
 
 
 ################################################################################
 # Dependencies
 ################################################################################
-# Boost Headers
-set( Boost_MINIMUM_VERSION "1.47" )
-include_directories( ${Boost_INCLUDE_DIR} )
-
-# NetCDF
 find_package( NetCDF REQUIRED COMPONENTS Fortran )
-include_directories( ${NETCDF_INCLUDE_DIRS} )
-
-# eckit
-ecbuild_use_package( PROJECT eckit VERSION 1.1.0 REQUIRED )
-include_directories( ${ECKIT_INCLUDE_DIRS} )
-link_libraries( ${ECKIT_LIBRARIES} )
-
-# fckit
-ecbuild_use_package( PROJECT fckit VERSION 0.4.1 REQUIRED )
-include_directories( ${FCKIT_INCLUDE_DIRS} )
-
-# atlas
-ecbuild_use_package( PROJECT atlas VERSION 0.18.1 REQUIRED )
-include_directories( ${ATLAS_INCLUDE_DIRS} )
-
-# oops
-ecbuild_use_package( PROJECT oops VERSION 0.1.0 REQUIRED )
-include_directories( ${OOPS_INCLUDE_DIRS} )
-add_definitions(-DATLASIFIED=1)
-
-# saber
-ecbuild_use_package( PROJECT saber VERSION 0.0.1 REQUIRED )
-include_directories( ${SABER_INCLUDE_DIRS} )
-
-# ioda
-ecbuild_use_package( PROJECT ioda VERSION 0.1.0 REQUIRED )
-include_directories( ${IODA_INCLUDE_DIRS} )
-
-# ufo
-ecbuild_use_package( PROJECT ufo VERSION 0.1.0 REQUIRED )
-include_directories( ${UFO_INCLUDE_DIRS} )
-
-# MPI
-ecbuild_find_mpi( COMPONENTS CXX Fortran REQUIRED )
-ecbuild_include_mpi()
-link_libraries(${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES})
-
-
-################################################################################
-# Export package info
-################################################################################
-list( APPEND UMDSST_TPLS atlas atlas_f LAPACK MPI NetCDF )
-
-set( UMDSST_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src
-                       ${CMAKE_CURRENT_BINARY_DIR}/src
-                       ${CMAKE_Fortran_MODULE_DIRECTORY} )
-set( UMDSST_LIBRARIES umdsst )
-
-get_directory_property( UMDSST_DEFINITIONS COMPILE_DEFINITIONS )
-
-foreach( _tpl ${UMDSST_TPLS} )
-string( TOUPPER ${_tpl} TPL )
-list( APPEND UMDSST_EXTRA_DEFINITIONS   ${${TPL}_DEFINITIONS}  ${${TPL}_TPL_DEFINITIONS}  )
-list( APPEND UMDSST_EXTRA_INCLUDE_DIRS  ${${TPL}_INCLUDE_DIRS} ${${TPL}_TPL_INCLUDE_DIRS} )
-list( APPEND UMDSST_EXTRA_LIBRARIES     ${${TPL}_LIBRARIES}    ${${TPL}_TPL_LIBRARIES}    )
-endforeach()
+find_package( eckit  1.11.6   REQUIRED)
+find_package( fckit  0.7.0    REQUIRED)
+find_package( atlas  0.20.2   REQUIRED)
+find_package( oops   1.0.0    REQUIRED)
+find_package( saber  1.0.0    REQUIRED)
+find_package( ioda   1.0.0    REQUIRED)
+find_package( ufo    1.0.0    REQUIRED)
 
 
 ################################################################################
 # Sources
 ################################################################################
-include( umdsst_compiler_flags )
-include_directories( ${UMDSST_INCLUDE_DIRS} ${UMDSST_EXTRA_INCLUDE_DIRS} )
-
+set( UMDSST_LINKER_LANGUAGE CXX )
 add_subdirectory( src )
 add_subdirectory( test )
 
-if(ECBUILD_INSTALL_FORTRAN_MODULES)
-  install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR} DESTINATION ${INSTALL_INCLUDE_DIR} )
-endif()
 
 ################################################################################
 # Finalise configuration

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -26,13 +26,13 @@ endif ()
 
 option(BUILD_FCKIT "download and build fckit (not needed if in a jedi container)")
 if (BUILD_FCKIT)
-  ecbuild_bundle( PROJECT fckit  GIT "https://github.com/jcsda-internal/fckit.git"  UPDATE BRANCH release-stable )
+  ecbuild_bundle( PROJECT fckit  GIT "https://github.com/jcsda/fckit.git"  UPDATE BRANCH release-stable )
   # TODO: replace with https://github.com/ecmwf/fckit.git TAG 0.9.2
 endif()
 
 option(BUILD_ATLAS "download and build atlas (not needed if in a jedi container)")
 if (BUILD_ATLAS)
-  ecbuild_bundle( PROJECT atlas  GIT "https://github.com/jcsda-internal/atlas.git"  UPDATE BRANCH release-stable )
+  ecbuild_bundle( PROJECT atlas  GIT "https://github.com/jcsda/atlas.git"  UPDATE BRANCH release-stable )
   # TODO: repalce with https://github.com/ecmwf/atlas.git TAG 0.24.1
 endif()
 

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -7,26 +7,39 @@
 # UMDSST-BUNDLE
 #
 
-project( UMDSST-bundle C CXX Fortran )
+cmake_minimum_required( VERSION 3.12 )
+project( umdsst-bundle VERSION 2021.5.0 LANGUAGES C CXX Fortran )
 
-cmake_minimum_required( VERSION 3.8 FATAL_ERROR )
+find_package( ecbuild 3.3.2 QUIET)
 include( ecbuild_bundle )
-
-set( ECBUILD_DEFAULT_BUILD_TYPE RelWithDebInfo )
-set( ENABLE_MPI ON CACHE BOOL "Compile with MPI" )
-
 ecbuild_bundle_initialize()
-ecbuild_requires_macro_version( 2.7 )
 
-# Optional repositories
-option( BUILD_ECKIT "download and build eckit (not needed if in a jedi container)" )
+
+#===================================================================================================
+# ECMWF repos that you probably dont need to build yourself because they should be in the
+# jedi-stack and containers
+#===================================================================================================
+option(BUILD_ECKIT "download and build eckit (not needed if in a jedi container)")
 if ( BUILD_ECKIT )
-  ecbuild_bundle( PROJECT eckit         GIT "https://github.com/jcsda/eckit.git"           UPDATE BRANCH release-stable )
+  ecbuild_bundle( PROJECT eckit  GIT "https://github.com/ecmwf/eckit.git"  UPDATE TAG 1.16.0 )
 endif ()
 
+option(BUILD_FCKIT "download and build fckit (not needed if in a jedi container)")
+if (BUILD_FCKIT)
+  ecbuild_bundle( PROJECT fckit  GIT "https://github.com/jcsda-internal/fckit.git"  UPDATE BRANCH release-stable )
+  # TODO: replace with https://github.com/ecmwf/fckit.git TAG 0.9.2
+endif()
+
+option(BUILD_ATLAS "download and build atlas (not needed if in a jedi container)")
+if (BUILD_ATLAS)
+  ecbuild_bundle( PROJECT atlas  GIT "https://github.com/jcsda-internal/atlas.git"  UPDATE BRANCH release-stable )
+  # TODO: repalce with https://github.com/ecmwf/atlas.git TAG 0.24.1
+endif()
+
+
+#===================================================================================================
 # required repositories
-ecbuild_bundle( PROJECT fckit           GIT "https://github.com/jcsda/fckit.git"           UPDATE BRANCH release-stable )
-ecbuild_bundle( PROJECT atlas           GIT "https://github.com/jcsda/atlas.git"           UPDATE BRANCH release-stable )
+#===================================================================================================
 ecbuild_bundle( PROJECT oops            GIT "https://github.com/jcsda/oops.git"            UPDATE BRANCH develop )
 ecbuild_bundle( PROJECT saber           GIT "https://github.com/jcsda/saber.git"           UPDATE BRANCH develop )
 ecbuild_bundle( PROJECT ioda            GIT "https://github.com/jcsda/ioda.git"            UPDATE BRANCH develop )

--- a/src/mains/CMakeLists.txt
+++ b/src/mains/CMakeLists.txt
@@ -4,7 +4,7 @@ ecbuild_add_executable( TARGET  umdsst_convertstate.x
 
 ecbuild_add_executable( TARGET  umdsst_dirac.x
                         SOURCES Dirac.cc
-                        LIBS    umdsst saber)
+                        LIBS    umdsst )
 
 ecbuild_add_executable( TARGET  umdsst_hofx3d.x
                         SOURCES HofX3D.cc
@@ -12,8 +12,8 @@ ecbuild_add_executable( TARGET  umdsst_hofx3d.x
 
 ecbuild_add_executable( TARGET  umdsst_staticbinit.x
                         SOURCES StaticBInit.cc
-                        LIBS    umdsst saber)
+                        LIBS    umdsst )
 
 ecbuild_add_executable( TARGET  umdsst_var.x
                         SOURCES Var.cc
-                        LIBS    umdsst saber)
+                        LIBS    umdsst )

--- a/src/umdsst/CMakeLists.txt
+++ b/src/umdsst/CMakeLists.txt
@@ -19,11 +19,22 @@ find_package( NetCDF REQUIRED COMPONENTS CXX )
 # the main library for this interface
 ecbuild_add_library( TARGET   umdsst
                      SOURCES  ${umdsst_src_files}
-                     LIBS     ${NETCDF_LIBRARIES}
-                              eckit eckit_mpi fckit oops ioda ufo saber
                      INSTALL_HEADERS LISTED
                      LINKER_LANGUAGE ${UMDSST_LINKER_LANGUAGE}
                     )
+target_include_directories(umdsst PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+  $<INSTALL_INTERFACE:include/umdsst>)
+
+target_compile_features( umdsst PUBLIC cxx_std_11 )
+
+target_link_libraries( umdsst PUBLIC NetCDF::NetCDF_CXX )
+target_link_libraries( umdsst PUBLIC fckit )
+target_link_libraries( umdsst PUBLIC atlas )
+target_link_libraries( umdsst PUBLIC oops )
+target_link_libraries( umdsst PUBLIC saber )
+target_link_libraries( umdsst PUBLIC ioda )
+target_link_libraries( umdsst PUBLIC ufo )
 
 # add source code in the subdirectories
 add_subdirectory(Covariance)


### PR DESCRIPTION
changes to the cmake files to be compatible with modules that use the newest ecbuild.

- This PR should be backward compatible with the currently used modules.
- fckit and atlas are disabled by default now in the bundle since they are included in the new modules.  If using the modules with the current ecbuild, you will have to use `-DBUILD_FCKIT=ON -DBUILD_ATLAS=ON` when running `ecbuild`. 