### PR TITLE
update to work with latest jedi repos

### DIFF
--- a/bundle/.gitignore
+++ b/bundle/.gitignore
@@ -3,6 +3,7 @@ eckit/
 fckit/
 ioda-converters/
 ioda/
+jedicmake/
 oops/
 saber/
 ufo/

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -15,6 +15,9 @@ include( ecbuild_bundle )
 ecbuild_bundle_initialize()
 
 
+ecbuild_bundle( PROJECT jedicmake GIT "https://github.com/jcsda-internal/jedi-cmake.git" UPDATE BRANCH develop )
+include( jedicmake/cmake/Functions/git_functions.cmake  )
+
 #===================================================================================================
 # ECMWF repos that you probably dont need to build yourself because they should be in the
 # jedi-stack and containers

--- a/test/Data/obs_sst.nc
+++ b/test/Data/obs_sst.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:42dd448285de892b5c38e721d2c055dbece53a140d4421fe965fc9dee06c0fd3
-size 25172
+oid sha256:2d2d1b743dd34e6d33c1fdb53c51f85046a23ad7bcacda45048924f033c9b6b1
+size 40369

--- a/test/test_wrapper.sh
+++ b/test/test_wrapper.sh
@@ -14,13 +14,15 @@ if [[ ${#CLEAN_FILES} -gt 0 ]]; then
         rm -f $f
     done
 fi
+test_output=testoutput/${COMPARE_TESTNAME}.log
+[[ -f "$test_output" ]] && rm $test_output
 
 # run the executable
 echo ""
 echo "==============================================================================="
 echo "Running test executable"
 echo "==============================================================================="
-${MPI_CMD} $1 $2 testoutput/${COMPARE_TESTNAME}.log
+${MPI_CMD} $1 $2 $test_output
 e=$?
 if [[ "$e" -gt 0 ]]; then
     echo -e "Failed to run executable. Error code: $e \n"
@@ -34,7 +36,7 @@ if [[ "$SKIP_COMPARE" == "FALSE" ]]; then
     echo "Running compare script"
     echo "==============================================================================="
 
-    $COMPARE_SCRIPT testoutput/${COMPARE_TESTNAME}.log \
+    $COMPARE_SCRIPT $test_output \
                     testref/${COMPARE_TESTNAME}.ref \
                     ${COMPARE_TOL_F} ${COMPARE_TOL_I}
     e=$?


### PR DESCRIPTION
small updates so that the develop branch will work again with the latest jedi repositories.

- observations were converted to the new ioda-v2 format
- old test output is deleted before running the test (needed because test output is now appended instead of overwriting)

I have not updated the cycling scripts to do the ioda-v1 to ioda-v2 conversion for the sst files, @loganchen39, so continue to use the `2021.5.0` tag for your experiments

closes https://github.com/UMD-AOSC/UMD-SST/issues/74